### PR TITLE
Fix/#4 듀오 추천 시 변경점

### DIFF
--- a/src/main/java/com/gnimty/communityapiserver/domain/riotaccount/controller/dto/request/CursorEntry.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/riotaccount/controller/dto/request/CursorEntry.java
@@ -1,0 +1,16 @@
+package com.gnimty.communityapiserver.domain.riotaccount.controller.dto.request;
+
+import com.gnimty.communityapiserver.global.constant.Tier;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class CursorEntry {
+
+	private Long lastSummonerId;
+	private String lastSummonerName;
+	private Tier lastSummonerTier;
+	private Integer lastSummonerDivision;
+	private Long lastSummonerUpCount;
+}

--- a/src/main/java/com/gnimty/communityapiserver/domain/riotaccount/controller/dto/request/RecommendedSummonersRequest.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/riotaccount/controller/dto/request/RecommendedSummonersRequest.java
@@ -24,8 +24,11 @@ public class RecommendedSummonersRequest {
 	private List<Lane> lanes;
 	private SortBy sortBy;
 	private Boolean timeMatch;
-	@NotNull(message = ErrorMessage.INVALID_INPUT_VALUE)
-	private Long cursorId;
+	private Long lastSummonerId;
+	private String lastSummonerName;
+	private Tier lastSummonerTier;
+	private Integer lastSummonerDivision;
+	private Long lastSummonerUpCount;
 	@NotNull(message = ErrorMessage.INVALID_INPUT_VALUE)
 	private Integer pageSize;
 
@@ -39,7 +42,11 @@ public class RecommendedSummonersRequest {
 			.lanes(lanes)
 			.sortBy(sortBy)
 			.timeMatch(timeMatch)
-			.cursorId(cursorId)
+			.lastSummonerId(lastSummonerId)
+			.lastSummonerName(lastSummonerName)
+			.lastSummonerTier(lastSummonerTier)
+			.lastSummonerDivision(lastSummonerDivision)
+			.lastSummonerUpCount(lastSummonerUpCount)
 			.pageSize(pageSize)
 			.build();
 	}

--- a/src/main/java/com/gnimty/communityapiserver/domain/riotaccount/repository/RiotAccountQueryRepository.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/riotaccount/repository/RiotAccountQueryRepository.java
@@ -168,7 +168,7 @@ public class RiotAccountQueryRepository {
 	}
 
 	private BooleanBuilder timeMatch(List<Schedule> schedules, Boolean timeMatch) {
-		if (!timeMatch) {
+		if (timeMatch == null || !timeMatch) {
 			return null;
 		}
 		BooleanBuilder builder = new BooleanBuilder();

--- a/src/main/java/com/gnimty/communityapiserver/domain/riotaccount/service/RiotAccountReadService.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/riotaccount/service/RiotAccountReadService.java
@@ -1,6 +1,7 @@
 package com.gnimty.communityapiserver.domain.riotaccount.service;
 
 import com.gnimty.communityapiserver.domain.member.entity.Member;
+import com.gnimty.communityapiserver.domain.riotaccount.controller.dto.request.CursorEntry;
 import com.gnimty.communityapiserver.domain.riotaccount.controller.dto.response.RecommendedSummonersEntry;
 import com.gnimty.communityapiserver.domain.riotaccount.entity.RiotAccount;
 import com.gnimty.communityapiserver.domain.riotaccount.repository.RiotAccountQueryRepository;
@@ -9,6 +10,7 @@ import com.gnimty.communityapiserver.domain.riotaccount.service.dto.request.Reco
 import com.gnimty.communityapiserver.domain.riotaccount.service.dto.response.RecommendedSummonersServiceResponse;
 import com.gnimty.communityapiserver.domain.schedule.entity.Schedule;
 import com.gnimty.communityapiserver.global.constant.GameMode;
+import com.gnimty.communityapiserver.global.constant.Tier;
 import com.gnimty.communityapiserver.global.exception.BaseException;
 import com.gnimty.communityapiserver.global.exception.ErrorCode;
 import java.util.List;
@@ -64,10 +66,26 @@ public class RiotAccountReadService {
 		List<Schedule> schedules
 	) {
 		List<RecommendedSummonersEntry> content = riotAccountQueryRepository.findSummonersByConditions(
-				Pageable.ofSize(request.getPageSize()), request, mainRiotAccount, schedules)
+				Pageable.ofSize(request.getPageSize()), request, mainRiotAccount, schedules,
+				buildCursorEntry(request))
 			.getContent();
 		return RecommendedSummonersServiceResponse.builder()
 			.recommendedSummoners(content)
+			.build();
+	}
+
+	private CursorEntry buildCursorEntry(RecommendedSummonersServiceRequest request) {
+		return CursorEntry.builder()
+			.lastSummonerName(
+				request.getLastSummonerName() == null ? "a" : request.getLastSummonerName())
+			.lastSummonerId(
+				request.getLastSummonerId() == null ? 0L : request.getLastSummonerId())
+			.lastSummonerTier(
+				request.getLastSummonerTier() == null ? Tier.NULL : request.getLastSummonerTier())
+			.lastSummonerDivision(
+				request.getLastSummonerDivision() == null ? 0 : request.getLastSummonerDivision())
+			.lastSummonerUpCount(
+				request.getLastSummonerUpCount() == null ? 0L : request.getLastSummonerUpCount())
 			.build();
 	}
 

--- a/src/main/java/com/gnimty/communityapiserver/domain/riotaccount/service/dto/request/RecommendedSummonersServiceRequest.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/riotaccount/service/dto/request/RecommendedSummonersServiceRequest.java
@@ -21,6 +21,10 @@ public class RecommendedSummonersServiceRequest {
 	private Boolean duoable;
 	private Boolean timeMatch;
 	private SortBy sortBy;
-	private Long cursorId;
+	private Long lastSummonerId;
+	private String lastSummonerName;
+	private Tier lastSummonerTier;
+	private Integer lastSummonerDivision;
+	private Long lastSummonerUpCount;
 	private Integer pageSize;
 }

--- a/src/main/java/com/gnimty/communityapiserver/global/constant/Tier.java
+++ b/src/main/java/com/gnimty/communityapiserver/global/constant/Tier.java
@@ -4,25 +4,29 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.gnimty.communityapiserver.global.exception.BaseException;
 import com.gnimty.communityapiserver.global.exception.ErrorCode;
 import java.util.stream.Stream;
+import lombok.Getter;
 
+@Getter
 public enum Tier {
 
-	CHALLENGER("challenger"),
-	GRANDMASTER("grandmaster"),
-	MASTER("master"),
-	DIAMOND("diamond"),
-	EMERALD("emerald"),
-	PLATINUM("platinum"),
-	GOLD("gold"),
-	SILVER("silver"),
-	BRONZE("bronze"),
-	IRON("iron"),
-	NULL("null");
+	CHALLENGER("challenger", 10),
+	GRANDMASTER("grandmaster", 9),
+	MASTER("master", 8),
+	DIAMOND("diamond", 7),
+	EMERALD("emerald", 6),
+	PLATINUM("platinum", 5),
+	GOLD("gold", 4),
+	SILVER("silver", 3),
+	BRONZE("bronze", 2),
+	IRON("iron", 1),
+	NULL("null", 0);
 
 	private final String tier;
+	private final Integer order;
 
-	Tier(String tier) {
+	Tier(String tier, Integer order) {
 		this.tier = tier;
+		this.order = order;
 	}
 
 	@JsonCreator(mode = JsonCreator.Mode.DELEGATING)


### PR DESCRIPTION
1. cursor의 정의가 다음과 같이 변경됩니다.
```
private Long lastSummonerId;
private String lastSummonerName;
private Tier lastSummonerTier;
private Integer lastSummonerDivision;
private Long lastSummonerUpCount;
```

- 다중 컬럼 orderBy에 대한 where절 커서 처리는 [다음과 같이](https://stackoverflow.com/questions/38017054/mysql-cursor-based-pagination-with-multiple-columns) 처리했습니다.


2. SortBy request에 대한 동적 orderby를 위해 **OrderSpecifier**가 적용됩니다.

3. enum type에 순서를 부여하기 위해 **Case 구문**이 사용됩니다.


this closes #4 