### PR TITLE
Feat/#28 채팅 서비스 코드 테스트

### DIFF
--- a/src/main/java/com/gnimty/communityapiserver/CommunityapiserverApplication.java
+++ b/src/main/java/com/gnimty/communityapiserver/CommunityapiserverApplication.java
@@ -12,4 +12,5 @@ public class CommunityapiserverApplication {
 		SpringApplication.run(CommunityapiserverApplication.class, args);
 	}
 
+
 }

--- a/src/main/java/com/gnimty/communityapiserver/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/chat/controller/ChatController.java
@@ -76,7 +76,6 @@ public class ChatController {
 
 	// 채팅방 나가기
 	@SubscribeMapping("/chatRoom/exit/{chatRoomNo}")
-
 	public void exitChatRoom(@DestinationVariable("chatRoomNo") Long chatRoomNo,
 							 @Header("simpSessionId") String sessionId) {
 		User user = getUserBySessionId(sessionId);

--- a/src/main/java/com/gnimty/communityapiserver/domain/chat/entity/User.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/chat/entity/User.java
@@ -20,6 +20,7 @@ import org.springframework.data.mongodb.core.mapping.Document;
 @AllArgsConstructor
 @NoArgsConstructor
 @ToString
+@EqualsAndHashCode
 public class User {
 	@Id
 	private String id;

--- a/src/main/java/com/gnimty/communityapiserver/domain/chat/repository/Chat/ChatRepository.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/chat/repository/Chat/ChatRepository.java
@@ -12,7 +12,7 @@ public interface ChatRepository extends MongoRepository<Chat, String>, ChatRepos
 
 	List<Chat> findByChatRoomNo(Long chatRoomNo);
 
-	List<Chat> findBySenderIdAndChatRoomNo(String senderId, Long chatRoomNo);
+	List<Chat> findBySenderIdAndChatRoomNo(Long senderId, Long chatRoomNo);
 
 	//void updateReadCountById(Long id, Integer readCount);
 

--- a/src/main/java/com/gnimty/communityapiserver/domain/chat/service/ChatService.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/chat/service/ChatService.java
@@ -178,14 +178,19 @@ public class ChatService {
 
 	// TODO janguni: 채팅 저장
 	public void saveChat(User user, Long chatRoomNo, String message) {
+		Date now = new Date();
+
 		Chat chat = Chat.builder()
 			.senderId(user.getActualUserId())
 			.chatRoomNo(chatRoomNo)
 			.message(message)
-			.sendDate(new Date())
+			.sendDate(now)
 			.readCnt(1)
 			.build();
+		ChatRoom chatRoom = getChatRoom(chatRoomNo);
 
+		chatRoom.setLastModifiedDate(now);
+		chatRoomRepository.save(chatRoom);
 		chatRepository.save(chat);
 	}
 

--- a/src/main/java/com/gnimty/communityapiserver/domain/chat/service/ChatService.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/chat/service/ChatService.java
@@ -230,11 +230,11 @@ public class ChatService {
 	}
 
 
-	private static List<ChatDto> getChatDtoAfterExitDate(List<Chat> totalChats, Date exitDate) {
+	private List<ChatDto> getChatDtoAfterExitDate(List<Chat> totalChats, Date exitDate) {
 		return totalChats.stream()
-			.filter(c -> exitDate == null || c.getSendDate().after(exitDate))
+			.filter(chat -> exitDate == null || chat.getSendDate().after(exitDate))
 			.map(ChatDto::new)
-			.collect(Collectors.toList());
+			.toList();
 	}
 
 

--- a/src/test/java/com/gnimty/communityapiserver/domain/chat/repository/ChatRoomRepositoryTest.java
+++ b/src/test/java/com/gnimty/communityapiserver/domain/chat/repository/ChatRoomRepositoryTest.java
@@ -1,5 +1,7 @@
 package com.gnimty.communityapiserver.domain.chat.repository;
 
+import static org.assertj.core.api.Assertions.*;
+
 import com.gnimty.communityapiserver.domain.chat.entity.ChatRoom;
 import com.gnimty.communityapiserver.domain.chat.entity.User;
 import com.gnimty.communityapiserver.domain.chat.repository.Chat.ChatRepository;
@@ -13,7 +15,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.jupiter.api.Assertions;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -99,8 +101,7 @@ public class ChatRoomRepositoryTest {
 		for (ChatRoom result : results) {
 			System.out.println("result = " + result);
 		}
-
-		Assertions.assertEquals(results.size(), 9);
+		assertThat(results.size()).isEqualTo(9);
 	}
 
 	@Test
@@ -112,7 +113,7 @@ public class ChatRoomRepositoryTest {
 
 		Optional<ChatRoom> expected = chatRoomRepository.findByChatRoomNo(1L);
 
-		Assertions.assertEquals(result.get().getId(), expected.get().getId());
+		assertThat(result.get().getId()).isEqualTo(expected.get().getId());
 	}
 
 	@Test
@@ -121,7 +122,8 @@ public class ChatRoomRepositoryTest {
 		User user1 = all.get(0);
 		User user2 = all.get(1);
 
-		Assertions.assertThrows(BaseException.class, () -> chatRoomRepository.save(user1, user2, seqGeneratorService.generateSequence(ChatRoom.SEQUENCE_NAME)));
+		assertThatThrownBy(() -> chatRoomRepository.save(user1, user2, seqGeneratorService.generateSequence(ChatRoom.SEQUENCE_NAME)))
+			.isInstanceOf(BaseException.class);
 	}
 
 

--- a/src/test/java/com/gnimty/communityapiserver/domain/chat/repository/ChatRoomRepositoryTest.java
+++ b/src/test/java/com/gnimty/communityapiserver/domain/chat/repository/ChatRoomRepositoryTest.java
@@ -45,6 +45,7 @@ public class ChatRoomRepositoryTest {
 		mongoTemplate.remove(new Query(), "auto_sequence");
 	}
 
+	/**
 	void 채팅방_여러개_만들기() {
 		clear();
 		List<User> users = new ArrayList<>();
@@ -122,6 +123,7 @@ public class ChatRoomRepositoryTest {
 
 		Assertions.assertThrows(BaseException.class, () -> chatRoomRepository.save(user1, user2, seqGeneratorService.generateSequence(ChatRoom.SEQUENCE_NAME)));
 	}
+	**/
 
 //	@AfterEach
 //	void afterEach() {

--- a/src/test/java/com/gnimty/communityapiserver/domain/chat/repository/ChatRoomRepositoryTest.java
+++ b/src/test/java/com/gnimty/communityapiserver/domain/chat/repository/ChatRoomRepositoryTest.java
@@ -45,7 +45,7 @@ public class ChatRoomRepositoryTest {
 		mongoTemplate.remove(new Query(), "auto_sequence");
 	}
 
-	/**
+
 	void 채팅방_여러개_만들기() {
 		clear();
 		List<User> users = new ArrayList<>();
@@ -123,7 +123,7 @@ public class ChatRoomRepositoryTest {
 
 		Assertions.assertThrows(BaseException.class, () -> chatRoomRepository.save(user1, user2, seqGeneratorService.generateSequence(ChatRoom.SEQUENCE_NAME)));
 	}
-	**/
+
 
 //	@AfterEach
 //	void afterEach() {

--- a/src/test/java/com/gnimty/communityapiserver/domain/chat/repository/UserRepositoryTest.java
+++ b/src/test/java/com/gnimty/communityapiserver/domain/chat/repository/UserRepositoryTest.java
@@ -1,6 +1,8 @@
 package com.gnimty.communityapiserver.domain.chat.repository;
 
 
+import static org.assertj.core.api.Assertions.*;
+
 import com.gnimty.communityapiserver.domain.chat.entity.User;
 import com.gnimty.communityapiserver.domain.chat.repository.Chat.ChatRepository;
 import com.gnimty.communityapiserver.domain.chat.repository.ChatRoom.ChatRoomRepository;
@@ -9,7 +11,7 @@ import com.gnimty.communityapiserver.global.constant.Status;
 import com.gnimty.communityapiserver.global.constant.Tier;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.jupiter.api.Assertions;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -66,9 +68,8 @@ public class UserRepositoryTest {
 			"so1omon", Status.ONLINE);
 		User user2 = new User(null, 1L, 3L, Tier.DIAMOND, 3,
 			"so1omon", Status.ONLINE);
-
-		Assertions.assertThrows(DuplicateKeyException.class,
-			() -> userRepository.saveAll(List.of(user1, user2)));
+		assertThatThrownBy(() -> userRepository.saveAll(List.of(user1, user2)))
+				.isInstanceOf(DuplicateKeyException.class);
 	}
 
 //	@AfterEach

--- a/src/test/java/com/gnimty/communityapiserver/domain/chat/service/ChatServiceTest.java
+++ b/src/test/java/com/gnimty/communityapiserver/domain/chat/service/ChatServiceTest.java
@@ -157,11 +157,7 @@ class ChatServiceTest {
     }
 
     @Test
-    void test111() {
-
-
-
-    }
+    void
 
     @NotNull
     private ChatRoom block(User user1, User user2) {

--- a/src/test/java/com/gnimty/communityapiserver/domain/chat/service/ChatServiceTest.java
+++ b/src/test/java/com/gnimty/communityapiserver/domain/chat/service/ChatServiceTest.java
@@ -130,4 +130,32 @@ class ChatServiceTest {
 
     }
 
+
+    @Test
+    void isBlockParticipant_테스트() {
+        // given
+
+        // 유저 2명 저장
+        User user1 = new User(null, 100L, 100L, Tier.BRONZE, 1, "uni", Status.OFFLINE);
+        User user2 = new User(null, 101L, 101L, Tier.DIAMOND, 1, "joo", Status.ONLINE);
+        userRepository.save(user1);
+        userRepository.save(user2);
+
+        // 채팅방 저장 (user2가 user1을 차단)
+        UserWithBlockDto userWithBlockDto1 = new UserWithBlockDto(user1, Blocked.UNBLOCK);
+        UserWithBlockDto userWithBlockDto2 = new UserWithBlockDto(user2, Blocked.BLOCK);
+        ChatRoom chatRoom = chatRoomRepository.save(userWithBlockDto1, userWithBlockDto2,
+            seqGeneratorService.generateSequence(ChatRoom.SEQUENCE_NAME));
+
+
+        // when
+        boolean result1 = chatService.isBlockParticipant(chatRoom, user1);
+        boolean result2 = chatService.isBlockParticipant(chatRoom, user2);
+
+
+        // then
+        Assertions.assertFalse(result1);
+        Assertions.assertTrue(result2);
+    }
+
 }

--- a/src/test/java/com/gnimty/communityapiserver/domain/chat/service/ChatServiceTest.java
+++ b/src/test/java/com/gnimty/communityapiserver/domain/chat/service/ChatServiceTest.java
@@ -180,6 +180,19 @@ class ChatServiceTest {
         assertNotEquals(originLastModifiedDate, updatedChatRoom.getLastModifiedDate());
     }
 
+    @Test
+    void updateConnStatus_테스트() {
+        // given
+        User user = userRepository.findByActualUserId(0L).get();
+
+        // when
+        chatService.updateConnStatus(user, Status.AWAY);
+
+        // then
+        User updatedUser = userRepository.findByActualUserId(0L).get();
+        assertEquals(updatedUser.getStatus(), Status.AWAY);
+    }
+
     @NotNull
     private ChatRoom block(User user1, User user2) {
         ChatRoom chatRoom = chatRoomRepository.findByUsers(user1, user2).get();

--- a/src/test/java/com/gnimty/communityapiserver/domain/chat/service/ChatServiceTest.java
+++ b/src/test/java/com/gnimty/communityapiserver/domain/chat/service/ChatServiceTest.java
@@ -2,9 +2,7 @@ package com.gnimty.communityapiserver.domain.chat.service;
 
 
 import static java.lang.Thread.sleep;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-
+import static org.assertj.core.api.Assertions.*;
 import com.gnimty.communityapiserver.domain.chat.controller.dto.ChatDto;
 import com.gnimty.communityapiserver.domain.chat.controller.dto.ChatRoomDto;
 import com.gnimty.communityapiserver.domain.chat.entity.Blocked;
@@ -22,7 +20,6 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -108,8 +105,7 @@ class ChatServiceTest {
             System.out.printf("chatRoomId = %d, otherUserId = %d\n",
                 chatRoomDto.getChatRoomNo(), chatRoomDto.getOtherUser().getUserId());
         }
-
-        assertEquals(9, chatRoomsJoined.size());
+        assertThat(chatRoomsJoined.size()).isEqualTo(9);
     }
 
     @Test
@@ -122,15 +118,13 @@ class ChatServiceTest {
             new UserWithBlockDto(all.get(0),Blocked.UNBLOCK),
             new UserWithBlockDto(all.get(1),Blocked.UNBLOCK)
         );
-
-        assertEquals(chatRooms.get(0).getId(), chatRoom.getId());
+        assertThat(chatRooms.get(0).getId()).isEqualTo(chatRoom.getId());
         // 새로운 유저 쌍 생성
 
         ChatRoom chatRoom2= chatService.getOrCreateChatRoom(
             new UserWithBlockDto(all.get(1),Blocked.UNBLOCK),
             new UserWithBlockDto(all.get(2),Blocked.UNBLOCK));
-
-        assertEquals(19, chatRoom2.getChatRoomNo());
+        assertThat(chatRoom2.getChatRoomNo()).isEqualTo(19);
     }
 
     @Test
@@ -154,9 +148,10 @@ class ChatServiceTest {
         boolean result1 = chatService.isBlockParticipant(chatRoom, user1);
         boolean result2 = chatService.isBlockParticipant(chatRoom, user2);
 
+
         // then
-        Assertions.assertTrue(result1);
-        Assertions.assertFalse(result2);
+        assertThat(result1).isTrue();
+        assertThat(result2).isFalse();
     }
 
     @Test
@@ -175,8 +170,8 @@ class ChatServiceTest {
         // then
         List<Chat> chats = chatRepository.findByChatRoomNo(chatRoom.getChatRoomNo());
         ChatRoom updatedChatRoom = chatRoomRepository.findByChatRoomNo(chatRoom.getChatRoomNo()).get();
-        assertEquals(1, chats.size());
-        assertNotEquals(originLastModifiedDate, updatedChatRoom.getLastModifiedDate());
+        assertThat(chats.size()).isEqualTo(1);
+        assertThat(originLastModifiedDate).isBefore(updatedChatRoom.getLastModifiedDate());
     }
 
     @Test
@@ -189,7 +184,7 @@ class ChatServiceTest {
 
         // then
         User updatedUser = userRepository.findByActualUserId(0L).get();
-        assertEquals(updatedUser.getStatus(), Status.AWAY);
+        assertThat(updatedUser.getStatus()).isEqualTo(Status.AWAY);
     }
 
     @Test
@@ -225,9 +220,9 @@ class ChatServiceTest {
         List<Chat> chats = chatRepository.findByChatRoomNo(chatRoom.getChatRoomNo());
         for (Chat chat : chats) {
             if (chat.getSenderId().equals(user1.getActualUserId())) {
-                assertEquals(chat.getReadCnt(), 0);
+                assertThat(chat.getReadCnt()).isEqualTo(0);
             } else {
-                assertEquals(chat.getReadCnt(), 1);
+                assertThat(chat.getReadCnt()).isEqualTo(1);
             }
         }
     }
@@ -286,9 +281,9 @@ class ChatServiceTest {
 
         // then
         List<ChatDto> chatList1 = chatService.getChatList(user2, chatRoom.getChatRoomNo());
-        assertEquals(3, chatList1.size());
+        assertThat(chatList1.size()).isEqualTo(3);
         List<ChatDto> chatList2 = chatService.getChatList(user1, chatRoom.getChatRoomNo());
-        assertEquals(5, chatList2.size());
+        assertThat(chatList2.size()).isEqualTo(5);
     }
 
 

--- a/src/test/java/com/gnimty/communityapiserver/domain/chat/service/ChatServiceTest.java
+++ b/src/test/java/com/gnimty/communityapiserver/domain/chat/service/ChatServiceTest.java
@@ -1,6 +1,10 @@
 package com.gnimty.communityapiserver.domain.chat.service;
 
 
+import static java.lang.Thread.sleep;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
 import com.gnimty.communityapiserver.domain.chat.controller.dto.ChatDto;
 import com.gnimty.communityapiserver.domain.chat.controller.dto.ChatRoomDto;
 import com.gnimty.communityapiserver.domain.chat.entity.Blocked;
@@ -106,7 +110,7 @@ class ChatServiceTest {
                 chatRoomDto.getChatRoomNo(), chatRoomDto.getOtherUser().getUserId());
         }
 
-        Assertions.assertEquals(9, chatRoomsJoined.size());
+        assertEquals(9, chatRoomsJoined.size());
     }
 
     @Test
@@ -120,14 +124,14 @@ class ChatServiceTest {
             new UserWithBlockDto(all.get(1),Blocked.UNBLOCK)
         );
 
-        Assertions.assertEquals(chatRooms.get(0).getId(), chatRoom.getId());
+        assertEquals(chatRooms.get(0).getId(), chatRoom.getId());
         // 새로운 유저 쌍 생성
 
         ChatRoom chatRoom2= chatService.getOrCreateChatRoom(
             new UserWithBlockDto(all.get(1),Blocked.UNBLOCK),
             new UserWithBlockDto(all.get(2),Blocked.UNBLOCK));
 
-        Assertions.assertEquals(19, chatRoom2.getChatRoomNo());
+        assertEquals(19, chatRoom2.getChatRoomNo());
     }
 
     @Test
@@ -157,7 +161,24 @@ class ChatServiceTest {
     }
 
     @Test
-    void
+    void saveChat_테스트() throws InterruptedException {
+
+        // given
+        User user = userRepository.findByActualUserId(0L).get();
+        ChatRoom chatRoom = chatRoomRepository.findByChatRoomNo(1L).get();
+        Date originLastModifiedDate = chatRoom.getLastModifiedDate();
+        String message = "안녕하세요";
+
+        // when
+        sleep(3000);
+        chatService.saveChat(user, chatRoom.getChatRoomNo(), message);
+
+        // then
+        List<Chat> chats = chatRepository.findByChatRoomNo(chatRoom.getChatRoomNo());
+        ChatRoom updatedChatRoom = chatRoomRepository.findByChatRoomNo(chatRoom.getChatRoomNo()).get();
+        assertEquals(1, chats.size());
+        assertNotEquals(originLastModifiedDate, updatedChatRoom.getLastModifiedDate());
+    }
 
     @NotNull
     private ChatRoom block(User user1, User user2) {
@@ -213,9 +234,9 @@ class ChatServiceTest {
 
         // then
         List<ChatDto> chatList1 = chatService.getChatList(user2, chatRoom.getChatRoomNo());
-        Assertions.assertEquals(3, chatList1.size());
+        assertEquals(3, chatList1.size());
         List<ChatDto> chatList2 = chatService.getChatList(user1, chatRoom.getChatRoomNo());
-        Assertions.assertEquals(5, chatList2.size());
+        assertEquals(5, chatList2.size());
     }
 
 


### PR DESCRIPTION
- 채팅 서비스 test 작성

(그 외)
- User 클래스에 @EqualsAndHashCode 추가
     chatService.extractParticipant()에서 user 비교 시 동일성을 비교해서 chatService.isBlockParticipant()을 사용할 때  첫번째 조건이 무조건 false가 나옴 (첫번째 조건: extractParticipant의 리턴 시 첫번째 조건 )

- chatRepository.findBySenderIdAndChatRoomNo() 에서 첫번째 인수인 senderId가 String으로 잘못되어있어서 Long으로 바꿈
   Chat의 senderId의 타입은 Long

- 채팅 저장 시 chatRoom의 마지막 수정일자 update

