### PR TITLE
feat/#36 구독자에게 message 보낼 때의 type으로 구분으로 변경, 접속상태 보낼 때 bug 수정

### DIFF
--- a/src/main/java/com/gnimty/communityapiserver/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/chat/controller/ChatController.java
@@ -55,10 +55,9 @@ public class ChatController {
 		Boolean isMeBlock = blockReadService.existsByBlockerIdAndBlockedId(me.getActualUserId(), other.getActualUserId());
 		Boolean isOtherBlock = blockReadService.existsByBlockerIdAndBlockedId(other.getActualUserId(), me.getActualUserId());
 
-		ChatRoomDto chatRoomDto = chatService.getOrCreateChatRoom(
+		ChatRoomDto chatRoomDto = chatService.getOrCreateChatRoomDto(
 			new UserWithBlockDto(me, isMeBlock.equals(true) ? Blocked.BLOCK : Blocked.UNBLOCK),
-			new UserWithBlockDto(other,
-				isOtherBlock.equals(true) ? Blocked.BLOCK : Blocked.UNBLOCK)
+			new UserWithBlockDto(other, isOtherBlock.equals(true) ? Blocked.BLOCK : Blocked.UNBLOCK)
 		);
 
 		// getchatRoomNo를 호출하기 X

--- a/src/main/java/com/gnimty/communityapiserver/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/chat/controller/ChatController.java
@@ -4,7 +4,6 @@ import com.gnimty.communityapiserver.domain.block.service.BlockReadService;
 import com.gnimty.communityapiserver.domain.chat.controller.dto.ChatRoomDto;
 import com.gnimty.communityapiserver.domain.chat.controller.dto.MessageResponse;
 import com.gnimty.communityapiserver.domain.chat.entity.Blocked;
-import com.gnimty.communityapiserver.domain.chat.entity.ChatRoom;
 import com.gnimty.communityapiserver.domain.chat.entity.User;
 import com.gnimty.communityapiserver.domain.chat.service.ChatService;
 import com.gnimty.communityapiserver.domain.chat.service.dto.UserWithBlockDto;
@@ -64,11 +63,11 @@ public class ChatController {
 
 		// getchatRoomNo를 호출하기 X
 		// chatRoom을 먼저 생성 또는 조회 후 그 정보를 그대로 보내주거나 DTO로 변환해서 보내주는 게 좋아 보임
-		chatService.sendChatRoomToUserSubscribers(me.getId(), new MessageResponse(MessageType.CHATROOMINFO, chatRoomDto));
+		chatService.sendToUserSubscribers(me.getId(), new MessageResponse(MessageType.CHATROOMINFO, chatRoomDto));
 
 		if (!isOtherBlock)
 		{
-			chatService.sendChatRoomToUserSubscribers(other.getId(), new MessageResponse(MessageType.CHATROOMINFO, chatRoomDto));
+			chatService.sendToUserSubscribers(other.getId(), new MessageResponse(MessageType.CHATROOMINFO, chatRoomDto));
 		}
 	}
 
@@ -79,7 +78,7 @@ public class ChatController {
 							String message) {
 		User user = getUserBySessionId(sessionId);
 		chatService.saveChat(user, chatRoomNo, message);
-		chatService.sendChatToChatRoomSubscribers(chatRoomNo, new MessageResponse(MessageType.CHATMESSAGE, message));
+		chatService.sendToChatRoomSubscribers(chatRoomNo, new MessageResponse(MessageType.CHATMESSAGE, message));
 	}
 
 	// 채팅방 나가기

--- a/src/main/java/com/gnimty/communityapiserver/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/chat/controller/ChatController.java
@@ -1,8 +1,8 @@
 package com.gnimty.communityapiserver.domain.chat.controller;
 
 import com.gnimty.communityapiserver.domain.block.service.BlockReadService;
-import com.gnimty.communityapiserver.domain.block.service.BlockService;
 import com.gnimty.communityapiserver.domain.chat.controller.dto.ChatRoomDto;
+import com.gnimty.communityapiserver.domain.chat.controller.dto.MessageResponse;
 import com.gnimty.communityapiserver.domain.chat.entity.Blocked;
 import com.gnimty.communityapiserver.domain.chat.entity.ChatRoom;
 import com.gnimty.communityapiserver.domain.chat.entity.User;
@@ -11,6 +11,7 @@ import com.gnimty.communityapiserver.domain.chat.service.dto.UserWithBlockDto;
 import com.gnimty.communityapiserver.domain.member.service.MemberService;
 import com.gnimty.communityapiserver.domain.member.service.dto.request.StatusUpdateServiceRequest;
 import com.gnimty.communityapiserver.global.auth.WebSocketSessionManager;
+import com.gnimty.communityapiserver.global.constant.MessageType;
 import com.gnimty.communityapiserver.global.constant.Status;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -52,22 +53,22 @@ public class ChatController {
 		User me = getUserBySessionId(sessionId);
 		User other = chatService.getUser(otherUserId);
 
-		// TODO janguni: 여기서 MemberService 호출해서 유저가 나를 차단했는지 정보를 가져오기
 		Boolean isMeBlock = blockReadService.existsByBlockerIdAndBlockedId(me.getActualUserId(), other.getActualUserId());
 		Boolean isOtherBlock = blockReadService.existsByBlockerIdAndBlockedId(other.getActualUserId(), me.getActualUserId());
 
-		ChatRoom chatRoom = chatService.getOrCreateChatRoom(
-			new UserWithBlockDto(me, isMeBlock.equals(true) ? Blocked.BLOCK	: Blocked.UNBLOCK),
-			new UserWithBlockDto(other, isOtherBlock.equals(false) ? Blocked.BLOCK : Blocked.UNBLOCK)
+		ChatRoomDto chatRoomDto = chatService.getOrCreateChatRoom(
+			new UserWithBlockDto(me, isMeBlock.equals(true) ? Blocked.BLOCK : Blocked.UNBLOCK),
+			new UserWithBlockDto(other,
+				isOtherBlock.equals(true) ? Blocked.BLOCK : Blocked.UNBLOCK)
 		);
 
 		// getchatRoomNo를 호출하기 X
 		// chatRoom을 먼저 생성 또는 조회 후 그 정보를 그대로 보내주거나 DTO로 변환해서 보내주는 게 좋아 보임
-		chatService.sendChatRoomToUserSubscribers(me.getId(), chatRoom.getChatRoomNo());
+		chatService.sendChatRoomToUserSubscribers(me.getId(), new MessageResponse(MessageType.CHATROOMINFO, chatRoomDto));
 
-		if (!chatService.isBlockParticipant(chatRoom, other)) //
+		if (!isOtherBlock)
 		{
-			chatService.sendChatRoomToUserSubscribers(other.getId(), chatRoom.getChatRoomNo());
+			chatService.sendChatRoomToUserSubscribers(other.getId(), new MessageResponse(MessageType.CHATROOMINFO, chatRoomDto));
 		}
 	}
 
@@ -78,7 +79,7 @@ public class ChatController {
 							String message) {
 		User user = getUserBySessionId(sessionId);
 		chatService.saveChat(user, chatRoomNo, message);
-		chatService.sendChatToChatRoomSubscribers(chatRoomNo, message);
+		chatService.sendChatToChatRoomSubscribers(chatRoomNo, new MessageResponse(MessageType.CHATMESSAGE, message));
 	}
 
 	// 채팅방 나가기
@@ -89,13 +90,6 @@ public class ChatController {
 		chatService.exitChatRoom(user, chatService.getChatRoom(chatRoomNo));
 	}
 
-	// chatRoomNo을 통한 sendStatus 필요
-	@MessageMapping("/chatRoom/status/{chatRoomNo}")
-	public void sendStatus(@DestinationVariable("chatRoomNo") Long chatRoomNo,
-		  				   @Header("simpSessionId") String sessionId,
-		                   String message) {
-		chatService.sendChatToChatRoomSubscribers(chatRoomNo, message);
-	}
 
 	@EventListener
 	public void onClientDisconnect(SessionDisconnectEvent event) {

--- a/src/main/java/com/gnimty/communityapiserver/domain/chat/controller/dto/MessageResponse.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/chat/controller/dto/MessageResponse.java
@@ -1,0 +1,16 @@
+package com.gnimty.communityapiserver.domain.chat.controller.dto;
+
+import com.gnimty.communityapiserver.global.constant.MessageType;
+import lombok.Data;
+
+@Data
+public class MessageResponse {
+
+    private MessageType type;
+    private Object data;
+
+    public MessageResponse(MessageType type, Object data) {
+        this.type = type;
+        this.data = data;
+    }
+}

--- a/src/main/java/com/gnimty/communityapiserver/domain/chat/service/ChatService.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/chat/service/ChatService.java
@@ -54,7 +54,7 @@ public class ChatService {
     // TODO solomon: 채팅방 생성 또는 조회
     // 이미 차단정보 확인된 상황
     public ChatRoomDto getOrCreateChatRoomDto(UserWithBlockDto me, UserWithBlockDto other) {
-        Optional<ChatRoom> nullableChatRoom = chatRoomRepository.findByUsers(me.getUser(), other.getUser());
+		Optional<ChatRoom> nullableChatRoom = chatRoomRepository.findByUsers(me.getUser(), other.getUser());
 		ChatRoom chatRoom = nullableChatRoom.orElseGet(() ->
 			chatRoomRepository.save(me, other, generator.generateSequence(ChatRoom.SEQUENCE_NAME))
 		);

--- a/src/main/java/com/gnimty/communityapiserver/domain/chat/service/ChatService.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/chat/service/ChatService.java
@@ -53,7 +53,7 @@ public class ChatService {
 
     // TODO solomon: 채팅방 생성 또는 조회
     // 이미 차단정보 확인된 상황
-    public ChatRoomDto getOrCreateChatRoom(UserWithBlockDto me, UserWithBlockDto other) {
+    public ChatRoomDto getOrCreateChatRoomDto(UserWithBlockDto me, UserWithBlockDto other) {
         Optional<ChatRoom> nullableChatRoom = chatRoomRepository.findByUsers(me.getUser(), other.getUser());
 		ChatRoom chatRoom = nullableChatRoom.orElseGet(() ->
 			chatRoomRepository.save(me, other, generator.generateSequence(ChatRoom.SEQUENCE_NAME))

--- a/src/main/java/com/gnimty/communityapiserver/domain/chat/service/ChatService.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/chat/service/ChatService.java
@@ -130,9 +130,11 @@ public class ChatService {
 		User user = userRepository.save(User.toUser(riotAccount));
 
 		List<ChatRoom> chatRooms = chatRoomRepository.findByUser(user);
-		MessageResponse response = new MessageResponse(MessageType.USERINFO, new UserDto(user));
-
-		chatRooms.forEach(chatRoom -> sendToChatRoomSubscribers(chatRoom.getChatRoomNo(), response));
+		if (!chatRooms.isEmpty()) {
+			MessageResponse response = new MessageResponse(MessageType.USERINFO, new UserDto(user));
+			chatRooms.forEach(
+				chatRoom -> sendToChatRoomSubscribers(chatRoom.getChatRoomNo(), response));
+		}
     }
 
     // 차단

--- a/src/main/java/com/gnimty/communityapiserver/global/constant/MessageType.java
+++ b/src/main/java/com/gnimty/communityapiserver/global/constant/MessageType.java
@@ -1,0 +1,8 @@
+package com.gnimty.communityapiserver.global.constant;
+
+public enum MessageType {
+    USERINFO,
+    CONNECTSTATUS,
+    CHATROOMINFO,
+    CHATMESSAGE
+}

--- a/src/test/java/com/gnimty/communityapiserver/domain/chat/repository/ChatRoomRepositoryTest.java
+++ b/src/test/java/com/gnimty/communityapiserver/domain/chat/repository/ChatRoomRepositoryTest.java
@@ -47,7 +47,7 @@ public class ChatRoomRepositoryTest {
 		mongoTemplate.remove(new Query(), "auto_sequence");
 	}
 
-/**
+
 	void 채팅방_여러개_만들기() {
 		clear();
 		List<User> users = new ArrayList<>();
@@ -126,7 +126,7 @@ public class ChatRoomRepositoryTest {
 			.isInstanceOf(BaseException.class);
 	}
 
-**/
+
 //	@AfterEach
 //	void afterEach() {
 //		chatRoomRepository.deleteAll();

--- a/src/test/java/com/gnimty/communityapiserver/domain/chat/repository/ChatRoomRepositoryTest.java
+++ b/src/test/java/com/gnimty/communityapiserver/domain/chat/repository/ChatRoomRepositoryTest.java
@@ -47,7 +47,7 @@ public class ChatRoomRepositoryTest {
 		mongoTemplate.remove(new Query(), "auto_sequence");
 	}
 
-
+/**
 	void 채팅방_여러개_만들기() {
 		clear();
 		List<User> users = new ArrayList<>();
@@ -126,7 +126,7 @@ public class ChatRoomRepositoryTest {
 			.isInstanceOf(BaseException.class);
 	}
 
-
+**/
 //	@AfterEach
 //	void afterEach() {
 //		chatRoomRepository.deleteAll();

--- a/src/test/java/com/gnimty/communityapiserver/domain/chat/service/ChatServiceTest.java
+++ b/src/test/java/com/gnimty/communityapiserver/domain/chat/service/ChatServiceTest.java
@@ -114,17 +114,17 @@ class ChatServiceTest {
 
         List<ChatRoom> chatRooms = chatRoomRepository.findByUser(all.get(0));
         // 이미 존재하는 유저 쌍(0, 1번 유저)은 호출 시 기존 chatRoom인 첫 번째 chatRoom과 같음
-        ChatRoom chatRoom = chatService.getOrCreateChatRoom(
-            new UserWithBlockDto(all.get(0),Blocked.UNBLOCK),
-            new UserWithBlockDto(all.get(1),Blocked.UNBLOCK)
+        ChatRoomDto chatRoomDto1 = chatService.getOrCreateChatRoom(
+            new UserWithBlockDto(all.get(0), Blocked.UNBLOCK),
+            new UserWithBlockDto(all.get(1), Blocked.UNBLOCK)
         );
-        assertThat(chatRooms.get(0).getId()).isEqualTo(chatRoom.getId());
+        assertThat(chatRooms.get(0).getChatRoomNo()).isEqualTo(chatRoomDto1.getChatRoomNo());
         // 새로운 유저 쌍 생성
 
-        ChatRoom chatRoom2= chatService.getOrCreateChatRoom(
-            new UserWithBlockDto(all.get(1),Blocked.UNBLOCK),
-            new UserWithBlockDto(all.get(2),Blocked.UNBLOCK));
-        assertThat(chatRoom2.getChatRoomNo()).isEqualTo(19);
+        ChatRoomDto chatRoomDto2 = chatService.getOrCreateChatRoom(
+            new UserWithBlockDto(all.get(1), Blocked.UNBLOCK),
+            new UserWithBlockDto(all.get(2), Blocked.UNBLOCK));
+        assertThat(chatRoomDto2.getChatRoomNo()).isEqualTo(19);
     }
 
     @Test

--- a/src/test/java/com/gnimty/communityapiserver/domain/chat/service/ChatServiceTest.java
+++ b/src/test/java/com/gnimty/communityapiserver/domain/chat/service/ChatServiceTest.java
@@ -114,14 +114,14 @@ class ChatServiceTest {
 
         List<ChatRoom> chatRooms = chatRoomRepository.findByUser(all.get(0));
         // 이미 존재하는 유저 쌍(0, 1번 유저)은 호출 시 기존 chatRoom인 첫 번째 chatRoom과 같음
-        ChatRoomDto chatRoomDto1 = chatService.getOrCreateChatRoom(
+        ChatRoomDto chatRoomDto1 = chatService.getOrCreateChatRoomDto(
             new UserWithBlockDto(all.get(0), Blocked.UNBLOCK),
             new UserWithBlockDto(all.get(1), Blocked.UNBLOCK)
         );
         assertThat(chatRooms.get(0).getChatRoomNo()).isEqualTo(chatRoomDto1.getChatRoomNo());
         // 새로운 유저 쌍 생성
 
-        ChatRoomDto chatRoomDto2 = chatService.getOrCreateChatRoom(
+        ChatRoomDto chatRoomDto2 = chatService.getOrCreateChatRoomDto(
             new UserWithBlockDto(all.get(1), Blocked.UNBLOCK),
             new UserWithBlockDto(all.get(2), Blocked.UNBLOCK));
         assertThat(chatRoomDto2.getChatRoomNo()).isEqualTo(19);


### PR DESCRIPTION
- 구독자에게 메세지 보낼 때 MessageResponse를 보냄
   MessageResponse.type으로 메세지타입 구분

- chatService에서 채팅방 생성및 조회 시 return을 chatRoomdto로 변경

- chatService에서 createOrUpdateUser() 로직 변경
   user가 있든없든 save() -> 없으면 insert, 있으면 update 하니까,     (아니면 말해주세요!)
   해당 user가 존재하는 채팅방의 구독자에게 메세지(변경된 유저 정보) 보내기 

- 접속 정보 변동시 해당 유저가 존재하는 채팅방의 구독자에게 메세지(변경된 유저 접속상태) 보내기