### PR TITLE
Fix/#38 ChatService 의존 메서드 작성

### DIFF
--- a/src/main/java/com/gnimty/communityapiserver/domain/block/controller/BlockController.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/block/controller/BlockController.java
@@ -10,6 +10,10 @@ import com.gnimty.communityapiserver.domain.block.controller.dto.response.BlockR
 import com.gnimty.communityapiserver.domain.block.service.BlockReadService;
 import com.gnimty.communityapiserver.domain.block.service.BlockService;
 import com.gnimty.communityapiserver.domain.block.service.dto.response.BlockReadServiceResponse;
+import com.gnimty.communityapiserver.domain.chat.entity.Blocked;
+import com.gnimty.communityapiserver.domain.chat.service.ChatService;
+import com.gnimty.communityapiserver.domain.member.entity.Member;
+import com.gnimty.communityapiserver.global.auth.MemberThreadLocal;
 import com.gnimty.communityapiserver.global.response.CommonResponse;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +31,7 @@ public class BlockController {
 
 	private final BlockReadService blockReadService;
 	private final BlockService blockService;
+	private final ChatService chatService;
 
 	@GetMapping
 	public CommonResponse<BlockReadResponse> readBlocks() {
@@ -36,13 +41,17 @@ public class BlockController {
 
 	@PostMapping
 	public CommonResponse<Void> doBlock(@RequestBody @Valid BlockRequest request) {
-		blockService.doBlock(request.toServiceRequest());
+		Member member = MemberThreadLocal.get();
+		blockService.doBlock(member, request.toServiceRequest());
+		chatService.updateBlockStatus(member.getId(), request.getId(), Blocked.BLOCK);
 		return CommonResponse.success(SUCCESS_BLOCK, OK);
 	}
 
 	@DeleteMapping
 	public CommonResponse<Void> clearBlock(@RequestBody @Valid BlockClearRequest request) {
-		blockService.clearBlock(request.toServiceRequest());
+		Member member = MemberThreadLocal.get();
+		blockService.clearBlock(member, request.toServiceRequest());
+		chatService.updateBlockStatus(member.getId(), request.getId(), Blocked.UNBLOCK);
 		return CommonResponse.success(SUCCESS_CLEAR_BLOCK, OK);
 	}
 }

--- a/src/main/java/com/gnimty/communityapiserver/domain/block/service/BlockService.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/block/service/BlockService.java
@@ -6,7 +6,6 @@ import com.gnimty.communityapiserver.domain.block.service.dto.request.BlockClear
 import com.gnimty.communityapiserver.domain.block.service.dto.request.BlockServiceRequest;
 import com.gnimty.communityapiserver.domain.member.entity.Member;
 import com.gnimty.communityapiserver.domain.member.service.MemberReadService;
-import com.gnimty.communityapiserver.global.auth.MemberThreadLocal;
 import com.gnimty.communityapiserver.global.exception.BaseException;
 import com.gnimty.communityapiserver.global.exception.ErrorCode;
 import java.util.Objects;
@@ -23,8 +22,7 @@ public class BlockService {
 	private final BlockRepository blockRepository;
 	private final BlockReadService blockReadService;
 
-	public void doBlock(BlockServiceRequest request) {
-		Member member = MemberThreadLocal.get();
+	public void doBlock(Member member, BlockServiceRequest request) {
 		if (Objects.equals(request.getId(), member.getId())) {
 			throw new BaseException(ErrorCode.NOT_ALLOWED_SELF_BLOCK);
 		}
@@ -35,8 +33,7 @@ public class BlockService {
 		blockRepository.save(createBlockEntity(request, member, blocked));
 	}
 
-	public void clearBlock(BlockClearServiceRequest request) {
-		Member member = MemberThreadLocal.get();
+	public void clearBlock(Member member, BlockClearServiceRequest request) {
 		Block block = blockReadService.findById(request.getId());
 		if (!Objects.equals(block.getBlocker().getId(), member.getId())) {
 			throw new BaseException(ErrorCode.NO_PERMISSION);


### PR DESCRIPTION
this closes #38 

- 차단 시, ```chatService.updateBlockStatus()```
- 차단 해제 시, ```chatService.updateBlockStatus()```
- rso 연결(최초 또는 추가)시, ```chatService.createOrUpdateUser()```
- main riot account 변경 시, ```chatService.createOrUpdateUser()```
- 회원 상태 변경 시, ```chatService.updateConnStatus()```

@so1omon riot account bulk update시에도 ```chatService.createOrUpdateUser()```를 호출해야할까요? 만약 호출해야 한다면 다른 방안을 찾아야할 것 같습니다.