### PR TITLE
Feat/#43 repository func enhance

### DIFF
--- a/src/main/java/com/gnimty/communityapiserver/domain/block/controller/BlockController.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/block/controller/BlockController.java
@@ -11,7 +11,7 @@ import com.gnimty.communityapiserver.domain.block.service.BlockReadService;
 import com.gnimty.communityapiserver.domain.block.service.BlockService;
 import com.gnimty.communityapiserver.domain.block.service.dto.response.BlockReadServiceResponse;
 import com.gnimty.communityapiserver.domain.chat.entity.Blocked;
-import com.gnimty.communityapiserver.domain.chat.service.ChatService;
+import com.gnimty.communityapiserver.domain.chat.service.StompService;
 import com.gnimty.communityapiserver.domain.member.entity.Member;
 import com.gnimty.communityapiserver.global.auth.MemberThreadLocal;
 import com.gnimty.communityapiserver.global.response.CommonResponse;
@@ -31,7 +31,7 @@ public class BlockController {
 
 	private final BlockReadService blockReadService;
 	private final BlockService blockService;
-	private final ChatService chatService;
+	private final StompService chatService;
 
 	@GetMapping
 	public CommonResponse<BlockReadResponse> readBlocks() {

--- a/src/main/java/com/gnimty/communityapiserver/domain/chat/entity/Chat.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/chat/entity/Chat.java
@@ -25,14 +25,14 @@ public class Chat {
 	private Long senderId;
 	private String message;
 	private Date sendDate;
-	private Integer readCnt;
+	private Integer readCnt = 1;
 
 	@Builder
-	public Chat(Long chatRoomNo, Long senderId, String message, Date sendDate, Integer readCnt) {
+	public Chat(Long chatRoomNo, Long senderId, String message, Date sendDate) {
 		this.chatRoomNo = chatRoomNo;
 		this.senderId = senderId;
 		this.message = message;
 		this.sendDate = sendDate;
-		this.readCnt = readCnt;
+		// chat을 보내면 readCnt는 항상 1로 생성됨
 	}
 }

--- a/src/main/java/com/gnimty/communityapiserver/domain/chat/entity/ChatRoom.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/chat/entity/ChatRoom.java
@@ -3,6 +3,7 @@ package com.gnimty.communityapiserver.domain.chat.entity;
 import java.util.Date;
 import java.util.List;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -19,6 +20,7 @@ import org.springframework.data.mongodb.core.mapping.Document;
 @AllArgsConstructor
 @NoArgsConstructor
 @ToString
+@Builder
 public class ChatRoom {
 	// AutoIncrementSequence에서 ChatRoom을 위한 독립적인 SEQUENCE SCOPE로 작동
 	@Transient
@@ -36,6 +38,7 @@ public class ChatRoom {
 	@Setter
 	@AllArgsConstructor
 	@ToString
+	@Builder
 	public static class Participant{
 		@DBRef
 		private User user;
@@ -44,4 +47,8 @@ public class ChatRoom {
 	}
 
 	private Date lastModifiedDate;
+
+	private void refreshModifiedDate(){
+		this.lastModifiedDate = new Date();
+	}
 }

--- a/src/main/java/com/gnimty/communityapiserver/domain/chat/entity/User.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/chat/entity/User.java
@@ -2,10 +2,14 @@ package com.gnimty.communityapiserver.domain.chat.entity;
 
 
 import com.gnimty.communityapiserver.domain.riotaccount.entity.RiotAccount;
+import com.gnimty.communityapiserver.global.constant.Lane;
 import com.gnimty.communityapiserver.global.constant.Status;
 import com.gnimty.communityapiserver.global.constant.Tier;
+import java.util.ArrayList;
+import java.util.List;
 import javax.persistence.Id;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -21,6 +25,7 @@ import org.springframework.data.mongodb.core.mapping.Document;
 @NoArgsConstructor
 @ToString
 @EqualsAndHashCode
+@Builder
 public class User {
 	@Id
 	private String id;
@@ -31,17 +36,33 @@ public class User {
 	private Long profileIconId;
 	private Tier tier;
 	private Integer division;
+	private Long lp;
 	private String summonerName;
 	private Status status;
 
+	private List<Lane> mostLanes;
+	private List<Long> mostChampions;
+
 	public static User toUser(RiotAccount riotAccount){
-		return new User(
-			null,
-			riotAccount.getMember().getId(),
-			riotAccount.getIconId(),
-			riotAccount.getQueue(),
-			riotAccount.getDivision(),
-			riotAccount.getSummonerName(),
-			riotAccount.getMember().getStatus());
+		List<Lane> mostLanes = List.of(riotAccount.getFrequentLane1(),
+			riotAccount.getFrequentLane2());
+		List<Long> mostChampions = List.of(
+			riotAccount.getFrequentChampionId1(),
+			riotAccount.getFrequentChampionId2(),
+			riotAccount.getFrequentChampionId3());
+
+		mostLanes.removeIf(lane -> lane==null);
+		mostChampions.removeIf(champion -> champion==null);
+
+		return User.builder()
+			.actualUserId(riotAccount.getMember().getId())
+			.profileIconId(riotAccount.getIconId())
+			.tier(riotAccount.getQueue())
+			.division(riotAccount.getDivision())
+			.summonerName(riotAccount.getSummonerName())
+			.mostLanes(mostLanes)
+			.mostChampions(mostChampions)
+			.lp(riotAccount.getLp())
+			.build();
 	}
 }

--- a/src/main/java/com/gnimty/communityapiserver/domain/chat/repository/Chat/ChatRepository.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/chat/repository/Chat/ChatRepository.java
@@ -17,4 +17,6 @@ public interface ChatRepository extends MongoRepository<Chat, String>, ChatRepos
 	//void updateReadCountById(Long id, Integer readCount);
 
 	void deleteByChatRoomNo(Long chatRoomNo);
+
+
 }

--- a/src/main/java/com/gnimty/communityapiserver/domain/chat/repository/ChatRoom/ChatRoomRepository.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/chat/repository/ChatRoom/ChatRoomRepository.java
@@ -12,4 +12,6 @@ public interface ChatRoomRepository extends MongoRepository<ChatRoom, String>,
 	ChatRoom findFirstByOrderByChatRoomNoDesc();
 
 	void deleteByChatRoomNo(Long chatRoomNo);
+
+	boolean existsByChatRoomNo(Long chatRoomNo);
 }

--- a/src/main/java/com/gnimty/communityapiserver/domain/chat/repository/ChatRoom/ChatRoomRepositoryCustom.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/chat/repository/ChatRoom/ChatRoomRepositoryCustom.java
@@ -1,8 +1,10 @@
 package com.gnimty.communityapiserver.domain.chat.repository.ChatRoom;
 
 import com.gnimty.communityapiserver.domain.chat.entity.ChatRoom;
+import com.gnimty.communityapiserver.domain.chat.entity.ChatRoom.Participant;
 import com.gnimty.communityapiserver.domain.chat.entity.User;
 import com.gnimty.communityapiserver.domain.chat.service.dto.UserWithBlockDto;
+import com.mongodb.client.result.UpdateResult;
 import java.util.List;
 import java.util.Optional;
 
@@ -13,11 +15,7 @@ public interface ChatRoomRepositoryCustom {
 
 	Optional<ChatRoom> findByUsers(User user1, User user2);
 
-//    Optional<ChatRoom> findByConds(User user1, User user2, Long chaRoomNo);
+	ChatRoom save(List<Participant> participants);
 
-	ChatRoom save(UserWithBlockDto user1, UserWithBlockDto user2, Long chatRoomNo);
-
-	void updateExitDate(Long chatRoomNo, User me);
-
-	void updateBlock(Long chatRoomNo, User me);
+	UpdateResult update(ChatRoom chatRoom);
 }

--- a/src/main/java/com/gnimty/communityapiserver/domain/chat/repository/User/UserRepository.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/chat/repository/User/UserRepository.java
@@ -6,7 +6,6 @@ import java.util.Optional;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
 
-@Repository
 public interface UserRepository extends MongoRepository<User, Long>, UserRepositoryCustom {
 
 	Optional<User> findByActualUserId(Long userId);

--- a/src/main/java/com/gnimty/communityapiserver/domain/chat/repository/User/UserRepositoryCustom.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/chat/repository/User/UserRepositoryCustom.java
@@ -2,7 +2,9 @@ package com.gnimty.communityapiserver.domain.chat.repository.User;
 
 import com.gnimty.communityapiserver.domain.chat.entity.User;
 import com.gnimty.communityapiserver.global.constant.Status;
+import com.mongodb.bulk.BulkWriteResult;
+import java.util.List;
 
 public interface UserRepositoryCustom {
-
+    BulkWriteResult bulkUpdate(List<User> users);
 }

--- a/src/main/java/com/gnimty/communityapiserver/domain/chat/repository/User/UserRepositoryImpl.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/chat/repository/User/UserRepositoryImpl.java
@@ -1,8 +1,10 @@
 package com.gnimty.communityapiserver.domain.chat.repository.User;
 
+import com.gnimty.communityapiserver.domain.chat.entity.ChatRoom;
 import com.gnimty.communityapiserver.domain.chat.entity.User;
 import com.gnimty.communityapiserver.global.constant.Status;
 import com.mongodb.bulk.BulkWriteResult;
+import com.mongodb.client.result.UpdateResult;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -42,4 +44,5 @@ public class UserRepositoryImpl implements UserRepositoryCustom{
 
         return result;
     }
+
 }

--- a/src/main/java/com/gnimty/communityapiserver/domain/chat/repository/User/UserRepositoryImpl.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/chat/repository/User/UserRepositoryImpl.java
@@ -2,8 +2,44 @@ package com.gnimty.communityapiserver.domain.chat.repository.User;
 
 import com.gnimty.communityapiserver.domain.chat.entity.User;
 import com.gnimty.communityapiserver.global.constant.Status;
+import com.mongodb.bulk.BulkWriteResult;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.mongodb.core.BulkOperations;
+import org.springframework.data.mongodb.core.BulkOperations.BulkMode;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
 
+
+@RequiredArgsConstructor
 public class UserRepositoryImpl implements UserRepositoryCustom{
 
+    @Autowired
+    private final MongoTemplate mongoTemplate;
 
+    @Override
+    public BulkWriteResult bulkUpdate(List<User> users) {
+        BulkOperations bulkOperations = mongoTemplate.bulkOps(BulkMode.UNORDERED, "user");
+
+        for (User user : users) {
+            Query query = new Query(Criteria.where("actualUserId").is(user.getActualUserId()));
+            Update update = new Update()
+                .set("profileIconId", user.getProfileIconId())
+                .set("tier", user.getTier())
+                .set("division", user.getDivision())
+                .set("lp", user.getLp())
+                .set("summonerName", user.getSummonerName())
+                .set("mostLanes", user.getMostLanes())
+                .set("mostChampions", user.getMostChampions());
+
+            bulkOperations.updateOne(query, update);
+        }
+
+        BulkWriteResult result = bulkOperations.execute();
+
+        return result;
+    }
 }

--- a/src/main/java/com/gnimty/communityapiserver/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/chat/service/ChatRoomService.java
@@ -1,0 +1,82 @@
+package com.gnimty.communityapiserver.domain.chat.service;
+
+import static org.springframework.data.mongodb.core.FindAndModifyOptions.options;
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+import static org.springframework.data.mongodb.core.query.Query.query;
+
+import com.gnimty.communityapiserver.domain.chat.entity.AutoIncrementSequence;
+import com.gnimty.communityapiserver.domain.chat.entity.ChatRoom;
+import com.gnimty.communityapiserver.domain.chat.entity.ChatRoom.Participant;
+import com.gnimty.communityapiserver.domain.chat.entity.User;
+import com.gnimty.communityapiserver.domain.chat.repository.ChatRoom.ChatRoomRepository;
+import com.gnimty.communityapiserver.domain.chat.service.dto.UserWithBlockDto;
+import com.gnimty.communityapiserver.global.exception.BaseException;
+import com.gnimty.communityapiserver.global.exception.ErrorCode;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.mongodb.core.query.Update;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ChatRoomService {
+
+    private final ChatRoomRepository chatRoomRepository;
+
+    public Boolean checkChatRoom(Long chatRoomNo){
+        return chatRoomRepository.existsByChatRoomNo(chatRoomNo);
+    }
+
+    public Optional<ChatRoom> findChatRoom(User me, User other){
+        return chatRoomRepository.findByUsers(me, other);
+    }
+
+    public List<ChatRoom> findChatRoom(User user){
+        return chatRoomRepository.findByUser(user);
+    }
+
+
+    // TODO solomon : 단일 채팅방 정보 가져오기
+    public Optional<ChatRoom> findChatRoom(Long chatRoomNo){
+        return chatRoomRepository.findByChatRoomNo(chatRoomNo);
+    }
+
+    public ChatRoom getChatRoom(Long chatRoomNo){
+        return findChatRoom(chatRoomNo)
+            .orElseThrow(() -> new BaseException(ErrorCode.NOT_FOUND_CHAT_ROOM));
+    }
+
+    public ChatRoom getChatRoom(User me, User other){
+        return findChatRoom(me, other)
+            .orElseThrow(() -> new BaseException(ErrorCode.NOT_FOUND_CHAT_ROOM));
+    }
+
+    public ChatRoom save(UserWithBlockDto me, UserWithBlockDto other){
+        Optional<ChatRoom> bothJoined = findChatRoom(me.getUser(), other.getUser());
+
+        if (bothJoined.isPresent()){
+            throw new BaseException(ErrorCode.CHATROOM_ALREADY_EXISTS);
+        }
+
+        List<Participant> participants = List.of(
+            Participant.builder().user(me.getUser()).exitDate(null).blockedStatus(me.getStatus()).build(),
+            Participant.builder().user(other.getUser()).exitDate(null).blockedStatus(other.getStatus()).build()
+        );
+
+        return chatRoomRepository.save(participants);
+    }
+
+    public void delete(Long chatRoomNo){
+        chatRoomRepository.deleteByChatRoomNo(chatRoomNo);
+    }
+
+    public void update(ChatRoom chatRoom){
+        chatRoomRepository.update(chatRoom);
+    }
+}

--- a/src/main/java/com/gnimty/communityapiserver/domain/chat/service/ChatService.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/chat/service/ChatService.java
@@ -1,24 +1,12 @@
 package com.gnimty.communityapiserver.domain.chat.service;
 
-import com.gnimty.communityapiserver.domain.chat.controller.dto.ChatRoomDto;
-import com.gnimty.communityapiserver.domain.chat.controller.dto.MessageResponse;
-import com.gnimty.communityapiserver.domain.chat.controller.dto.UserDto;
-import com.gnimty.communityapiserver.domain.chat.entity.Blocked;
 import com.gnimty.communityapiserver.domain.chat.entity.Chat;
-import com.gnimty.communityapiserver.domain.chat.entity.ChatRoom;
-import com.gnimty.communityapiserver.domain.chat.entity.ChatRoom.Participant;
 import com.gnimty.communityapiserver.domain.chat.entity.User;
 import com.gnimty.communityapiserver.domain.chat.repository.Chat.ChatRepository;
 import com.gnimty.communityapiserver.domain.chat.repository.ChatRoom.ChatRoomRepository;
 import com.gnimty.communityapiserver.domain.chat.repository.User.UserRepository;
-import com.gnimty.communityapiserver.domain.chat.controller.dto.ChatDto;
-import com.gnimty.communityapiserver.domain.chat.service.dto.UserWithBlockDto;
-import com.gnimty.communityapiserver.domain.riotaccount.entity.RiotAccount;
-import com.gnimty.communityapiserver.global.constant.MessageType;
-import com.gnimty.communityapiserver.global.constant.Status;
 import com.gnimty.communityapiserver.global.exception.BaseException;
 import com.gnimty.communityapiserver.global.exception.ErrorCode;
-import com.mongodb.bulk.BulkWriteResult;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
@@ -27,287 +15,35 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 
+
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class ChatService {
 
-    private final ChatRoomRepository chatRoomRepository;
     private final ChatRepository chatRepository;
-    private final UserRepository userRepository;
-    private final SeqGeneratorService generator;
-	private final SimpMessagingTemplate template;
 
-    /*
-    TODO 리스트
-    채팅방 생성 또는 조회
-    채팅방 목록 불러오기 (status:UNBLOCK)
-    채팅방 나가기 (채팅방에 기록된 내 나간시간 기록 update)
-    채팅방별 채팅 목록 불러오기 (exitDate < sendDate)
-    유저정보 조회
-    채팅방에서 유저가 차단한 상태인지 확인
-    채팅 보내기
-    접속정보 변동내역 전송
-    채팅방의 모든 채팅내역 Flush
-    채팅 readCount check
-    */
-
-    // TODO solomon: 채팅방 생성 또는 조회
-    // 이미 차단정보 확인된 상황
-    public ChatRoomDto getOrCreateChatRoomDto(UserWithBlockDto me, UserWithBlockDto other) {
-		Optional<ChatRoom> nullableChatRoom = chatRoomRepository.findByUsers(me.getUser(), other.getUser());
-		ChatRoom chatRoom = nullableChatRoom.orElseGet(() ->
-			chatRoomRepository.save(me, other, generator.generateSequence(ChatRoom.SEQUENCE_NAME))
-		);
-
-		return ChatRoomDto.builder()
-			.chatRoom(chatRoom)
-			.other(new UserDto(other.getUser()))
-			.build();
+    public List<Chat> findChat(Long chatRoomNo) {
+        return chatRepository.findByChatRoomNo(chatRoomNo);
     }
 
-    // TODO solomon: 채팅방 목록 불러오기
-    // blocked==UNBLOCK인 도큐먼트만 조회
-    public List<ChatRoomDto> getChatRoomsJoined(User me) {
-
-        List<ChatRoom> chatRooms = chatRoomRepository.findByUser(me)
-            .stream().filter(chatRoom ->
-                extractParticipant(me, chatRoom.getParticipants(), true).getBlockedStatus()
-                    == Blocked.UNBLOCK
-            ).toList();
-
-        return chatRooms.stream().map(chatRoom ->
-            ChatRoomDto.builder()
-                .chats(getChatList(me, chatRoom.getChatRoomNo()))
-                .chatRoom(chatRoom)
-                .other(new UserDto(
-                    extractParticipant(me, chatRoom.getParticipants(), false).getUser()))
-                .build()
-        ).toList();
+    public Chat save(Chat chat) {
+        return chatRepository.save(chat);
     }
 
-    // TODO solomon: 채팅방 나가기 (채팅방에 기록된 내 나간시간 기록 update)
-    // 양쪽 다 채팅방을 나간 상황이면, 모든 채팅 기록 삭제
-    public void exitChatRoom(User me, ChatRoom chatRoom) {
-        Long chatRoomNo = chatRoom.getChatRoomNo();
-        Participant other = extractParticipant(me, chatRoom.getParticipants(), false);
-		Participant mine = extractParticipant(me, chatRoom.getParticipants(), false);
+    public Chat save(User user, Long chatRoomNo, String message, Date sendDate) {
+        Chat chat = Chat.builder()
+            .senderId(user.getActualUserId())
+            .chatRoomNo(chatRoomNo)
+            .message(message)
+            .sendDate(sendDate)
+            .build();
 
-        // chatRoom lastModifiedDate, 상대방의 exitDate 비교
-        if (other.getExitDate() != null
-            && chatRoom.getLastModifiedDate().before(other.getExitDate())) {
-            // (상대방이 채팅방 나간 상황) lastModifiedDate가 상대의 exitDate 이전일 때 : flush
-            //      -> flushAllChats() + chatRoomRepository.deleteByChatRoomNo()
-            flushAllChats(chatRoomNo);
-            chatRoomRepository.deleteByChatRoomNo(chatRoomNo);
-        } else {
-            // (상대방이 채팅방 나가지 않은 상황) lastModifiedDate가 상대의 exitDate 이후일 때 : exitDate update
-            //      -> chatRoomRepository.updateExitDate(me);
-            mine.setExitDate(new Date());
-            chatRoomRepository.save(chatRoom);
-        }
+        return chatRepository.save(chat);
     }
 
-    // TODO solomon : 단일 채팅방 정보 가져오기
-    public ChatRoom getChatRoom(Long chatRoomNo) {
-        return chatRoomRepository.findByChatRoomNo(chatRoomNo).orElseThrow(
-            () -> new BaseException(ErrorCode.NOT_FOUND_CHAT_ROOM,
-                String.format(ErrorCode.NOT_FOUND_CHAT_ROOM.getMessage(), chatRoomNo)));
+    public void delete(Long chatRoomNo) {
+        chatRepository.deleteByChatRoomNo(chatRoomNo);
     }
-
-    // TODO solomon : 유저정보 가져오기
-    public User getUser(Long actualUserId) throws BaseException {
-        Optional<User> user = userRepository.findByActualUserId(actualUserId);
-
-        if (user.isPresent()) {
-            return user.get();
-        } else {
-            throw new BaseException(ErrorCode.NOT_FOUND_CHAT_USER);
-        }
-    }
-
-
-    // TODO solomon : 유저정보 생성하기
-    public void createOrUpdateUser(RiotAccount riotAccount) {
-		User user = userRepository.save(User.toUser(riotAccount));
-
-		List<ChatRoom> chatRooms = chatRoomRepository.findByUser(user);
-		if (!chatRooms.isEmpty()) {
-			MessageResponse response = new MessageResponse(MessageType.USERINFO, new UserDto(user));
-			chatRooms.forEach(
-				chatRoom -> sendToChatRoomSubscribers(chatRoom.getChatRoomNo(), response));
-		}
-    }
-
-	public void createOrUpdateUser(List<RiotAccount> accounts){
-		List<User> users = accounts.stream().map(account-> User.toUser(account)).toList();
-
-		BulkWriteResult bulkWriteResult = userRepository.bulkUpdate(users);
-	}
-
-	// TODO so1omon : 특정 유저와 채팅을 나눈 member id list 넘기기
-	public List<Long> getChattedMemberIds(Long id){
-
-		// 0. 유저 정보 검색
-		User me = userRepository.findByActualUserId(id)
-			.orElseThrow(()-> new BaseException(ErrorCode.NOT_FOUND_CHAT_USER));
-
-		// 1. 내 정보로 chatRoom 리스트 검색
-		List<ChatRoom> chatRooms = chatRoomRepository.findByUser(me);
-
-		// 2. chatRoom에 속해 있는 모든 other participants 정보 검색하여 Id 추출
-		List<Long> memberIds = chatRooms.stream().map(chatRoom ->
-			 getOther(me, chatRoom).getActualUserId()).toList();
-
-		// 3. return
-		return memberIds;
-	}
-
-
-    // 차단
-    public void updateBlockStatus(Long meActualId, Long otherActualId, Blocked status) {
-        // 1. 나와 상대가 속해 있는 채팅방을 찾기 (수정예정)
-        try{
-			User me = getUser(meActualId);
-			User other = getUser(otherActualId);
-			ChatRoom chatRoom = chatRoomRepository.findByUsers(me, other)
-                .orElseThrow(() -> new BaseException(ErrorCode.NOT_FOUND_CHAT_ROOM));
-
-            // 2. 해당 채팅방의 participant 정보 수정 후 save
-            extractParticipant(me, chatRoom.getParticipants(), true).setBlockedStatus(status);
-
-            chatRoomRepository.save(chatRoom);
-
-            if (status == Blocked.BLOCK) {
-                exitChatRoom(me, chatRoom);
-            }
-
-        }catch(BaseException e){
-            log.info("두 유저가 존재하는 채팅방이 존재하지 않습니다.");
-        }
-    }
-
-
-   // TODO janguni : 유저가 차단했는지 확인
-	public boolean isBlockParticipant(ChatRoom chatRoom, User other) {
-		List<Participant> participants = chatRoom.getParticipants();
-		Participant participant = extractParticipant(other, participants, true);
-		return participant.getBlockedStatus().equals(Blocked.BLOCK);
-	}
-
-
-	// TODO janguni: 채팅방별 채팅 목록 불러오기 (exitDate < sendDate)
-	public List<ChatDto> getChatList(User me, Long chatRoomNo) {
-
-		// TODO: 시간 순서대로 오는건지 확인
-		List<Chat> totalChats = chatRepository.findByChatRoomNo(chatRoomNo);
-		Date exitDate = getExitDateChatRoom(chatRoomNo, me.getId());
-
-		return getChatDtoAfterExitDate(totalChats, exitDate);
-	}
-
-
-	// TODO janguni: 채팅 저장
-	public void saveChat(User user, Long chatRoomNo, String message) {
-		Date now = new Date();
-
-		Chat chat = Chat.builder()
-			.senderId(user.getActualUserId())
-			.chatRoomNo(chatRoomNo)
-			.message(message)
-			.sendDate(now)
-			.readCnt(1)
-			.build();
-		ChatRoom chatRoom = getChatRoom(chatRoomNo);
-
-		chatRoom.setLastModifiedDate(now);
-		chatRoomRepository.save(chatRoom);
-		chatRepository.save(chat);
-	}
-
-	// TODO janguni: 접속정보 변동내역 전송
-	public void updateConnStatus(User user, Status connectStatus) {
-		user.setStatus(connectStatus);
-		userRepository.save(user);
-
-		List<ChatRoom> chatRooms = chatRoomRepository.findByUser(user);
-		MessageResponse response = new MessageResponse(MessageType.CONNECTSTATUS, connectStatus);
-
-		chatRooms.forEach(chatRoom -> sendToChatRoomSubscribers(chatRoom.getChatRoomNo(), response));
-	}
-
-	// TODO januni: 채팅방의 모든 채팅내역 Flush
-	// 두명 다 나간 상황일 때만 호출
-	public void flushAllChats(Long chatRoomNo) {
-		chatRepository.deleteByChatRoomNo(chatRoomNo);
-	}
-
-	// TODO janguni: 채팅방에 있는 상대방이 보낸 채팅의 readCount update
-	public void checkChatsInChatRoom(User me, Long chatRoomNo) {
-		ChatRoom chatRoom = getChatRoom(chatRoomNo);
-
-		Long otherActualUserId = getOther(me, chatRoom).getActualUserId();
-
-		List<Chat> totalChats = chatRepository.findByChatRoomNo(chatRoomNo);
-		totalChats.stream()
-			.filter(chat -> (chat.getReadCnt() == 1 && chat.getSenderId().equals(otherActualUserId)))
-			.forEach(chat -> {
-				chat.setReadCnt(0);
-				chatRepository.save(chat);
-			});
-	}
-
-	public void sendToUserSubscribers(String userId, MessageResponse response){
-		template.convertAndSend("/sub/user/" + userId, response);
-	}
-
-	public void sendToChatRoomSubscribers(Long chatRoomId, MessageResponse response){
-		template.convertAndSend("/sub/chatRoom/" + chatRoomId, response);
-	}
-
-	private User getOther(User me, ChatRoom chatRoom) {
-		List<Participant> participants = chatRoom.getParticipants();
-		Participant participant = extractParticipant(me, participants, false);
-		User other = participant.getUser();
-		return other;
-	}
-
-
-	private List<ChatDto> getChatDtoAfterExitDate(List<Chat> totalChats, Date exitDate) {
-		return totalChats.stream()
-			.filter(chat -> exitDate == null || chat.getSendDate().after(exitDate))
-			.map(ChatDto::new)
-			.toList();
-	}
-
-
-	private Date getExitDateChatRoom(Long chatRoomNo, String senderId) {
-		ChatRoom findChatRoom = chatRoomRepository.findByChatRoomNo(chatRoomNo).get();
-		List<Participant> participants = findChatRoom.getParticipants();
-
-		for (Participant participant : participants) {
-			if (participant.getUser().getId().equals(senderId)) {
-				return participant.getExitDate();
-			}
-		}
-
-		throw new BaseException(ErrorCode.NOT_FOUND_CHAT_USER);
-
-	}
-
-
-	/**isMe==true이면 Participant List에서 내 Participant 정보를 추출
-	 * isMe==false이면 other user에 해당하는 Participant 정보를 추출
-	 * @param me 자신의 유저정보
-	 * @param participants 추출할 대상이 되는 Participant
-	 * @param isMe 자신의 유저정보를 가져올 것인지 여부
-	 * @return Participant
-	 */
-	public Participant extractParticipant(User me, List<Participant> participants, Boolean isMe) {
-		return participants.get(0).getUser().equals(me) ^ isMe ?
-			participants.get(1) : participants.get(0);
-	}
-
-
 
 }

--- a/src/main/java/com/gnimty/communityapiserver/domain/chat/service/ChatService.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/chat/service/ChatService.java
@@ -18,6 +18,7 @@ import com.gnimty.communityapiserver.global.constant.MessageType;
 import com.gnimty.communityapiserver.global.constant.Status;
 import com.gnimty.communityapiserver.global.exception.BaseException;
 import com.gnimty.communityapiserver.global.exception.ErrorCode;
+import com.mongodb.bulk.BulkWriteResult;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
@@ -137,6 +138,12 @@ public class ChatService {
 				chatRoom -> sendToChatRoomSubscribers(chatRoom.getChatRoomNo(), response));
 		}
     }
+
+	public void createOrUpdateUser(List<RiotAccount> accounts){
+		List<User> users = accounts.stream().map(account-> User.toUser(account)).toList();
+
+		BulkWriteResult bulkWriteResult = userRepository.bulkUpdate(users);
+	}
 
 	// TODO so1omon : 특정 유저와 채팅을 나눈 member id list 넘기기
 	public List<Long> getChattedMemberIds(Long id){
@@ -300,5 +307,7 @@ public class ChatService {
 		return participants.get(0).getUser().equals(me) ^ isMe ?
 			participants.get(1) : participants.get(0);
 	}
+
+
 
 }

--- a/src/main/java/com/gnimty/communityapiserver/domain/chat/service/SeqGeneratorService.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/chat/service/SeqGeneratorService.java
@@ -16,12 +16,5 @@ import org.springframework.stereotype.Service;
 public class SeqGeneratorService {
     private final MongoOperations mongoOperations;
 
-    public Long generateSequence(String seqName){
-        AutoIncrementSequence counter = mongoOperations.findAndModify(
-            query(where("_id").is(seqName)), new Update().inc("seq", 1),
-            options().returnNew(true).upsert(true),
-            AutoIncrementSequence.class);
 
-        return !Objects.isNull(counter) ? counter.getSeq() : 1;
-    }
 }

--- a/src/main/java/com/gnimty/communityapiserver/domain/chat/service/StompService.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/chat/service/StompService.java
@@ -1,0 +1,288 @@
+package com.gnimty.communityapiserver.domain.chat.service;
+
+import com.gnimty.communityapiserver.domain.chat.controller.dto.ChatRoomDto;
+import com.gnimty.communityapiserver.domain.chat.controller.dto.MessageResponse;
+import com.gnimty.communityapiserver.domain.chat.controller.dto.UserDto;
+import com.gnimty.communityapiserver.domain.chat.entity.Blocked;
+import com.gnimty.communityapiserver.domain.chat.entity.Chat;
+import com.gnimty.communityapiserver.domain.chat.entity.ChatRoom;
+import com.gnimty.communityapiserver.domain.chat.entity.ChatRoom.Participant;
+import com.gnimty.communityapiserver.domain.chat.entity.User;
+import com.gnimty.communityapiserver.domain.chat.controller.dto.ChatDto;
+import com.gnimty.communityapiserver.domain.chat.service.dto.UserWithBlockDto;
+import com.gnimty.communityapiserver.domain.riotaccount.entity.RiotAccount;
+import com.gnimty.communityapiserver.global.constant.MessageType;
+import com.gnimty.communityapiserver.global.constant.Status;
+import com.gnimty.communityapiserver.global.exception.BaseException;
+import com.gnimty.communityapiserver.global.exception.ErrorCode;
+import com.mongodb.bulk.BulkWriteResult;
+import java.util.Date;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class StompService {
+	private final SeqGeneratorService generator;
+	private final SimpMessagingTemplate template;
+	private final UserService userService;
+	private final ChatService chatService;
+	private final ChatRoomService chatRoomService;
+
+    /*
+    TODO 리스트
+    채팅방 생성 또는 조회
+    채팅방 목록 불러오기 (status:UNBLOCK)
+    채팅방 나가기 (채팅방에 기록된 내 나간시간 기록 update)
+    채팅방별 채팅 목록 불러오기 (exitDate < sendDate)
+    유저정보 조회
+    채팅방에서 유저가 차단한 상태인지 확인
+    채팅 보내기
+    접속정보 변동내역 전송
+    채팅방의 모든 채팅내역 Flush
+    채팅 readCount check
+    */
+
+    // TODO solomon: 채팅방 생성 또는 조회
+    // 이미 차단정보 확인된 상황
+	public ChatRoomDto getOrCreateChatRoomDto(UserWithBlockDto me, UserWithBlockDto other) {
+		ChatRoom chatRoom = chatRoomService.findChatRoom(me.getUser(), other.getUser())
+			.orElseGet(() -> chatRoomService.save(me, other));
+
+		return ChatRoomDto.builder()
+			.chatRoom(chatRoom)
+			.other(new UserDto(other.getUser()))
+			.build();
+	}
+
+    // TODO solomon: 채팅방 목록 불러오기
+    // blocked==UNBLOCK인 도큐먼트만 조회
+    public List<ChatRoomDto> getChatRoomsJoined(User me) {
+
+        List<ChatRoom> chatRooms = chatRoomService.findChatRoom(me)
+            .stream().filter(chatRoom ->
+                extractParticipant(me, chatRoom.getParticipants(), true).getBlockedStatus()
+                    == Blocked.UNBLOCK
+            ).toList();
+
+        return chatRooms.stream().map(chatRoom ->
+            ChatRoomDto.builder()
+                .chats(getChatList(me, chatRoom.getChatRoomNo()))
+                .chatRoom(chatRoom)
+                .other(new UserDto(
+                    extractParticipant(me, chatRoom.getParticipants(), false).getUser()))
+                .build()
+        ).toList();
+    }
+
+    // TODO solomon: 채팅방 나가기 (채팅방에 기록된 내 나간시간 기록 update)
+    // 양쪽 다 채팅방을 나간 상황이면, 모든 채팅 기록 삭제
+    public void exitChatRoom(User me, ChatRoom chatRoom) {
+        Participant other = extractParticipant(me, chatRoom.getParticipants(), false);
+		Participant mine = extractParticipant(me, chatRoom.getParticipants(), true);
+
+        // chatRoom lastModifiedDate, 상대방의 exitDate 비교
+
+		// (상대방이 채팅방 나간 상황) lastModifiedDate가 상대의 exitDate 이전일 때 : flush
+		//      -> flushAllChats() + chatRoomRepository.deleteByChatRoomNo()
+		if (other.getExitDate() != null
+			&& chatRoom.getLastModifiedDate().before(other.getExitDate())) {
+
+			Long chatRoomNo = chatRoom.getChatRoomNo();
+
+			chatService.delete(chatRoomNo);
+			chatRoomService.delete(chatRoomNo);
+		}
+		// (상대방이 채팅방 나가지 않은 상황) lastModifiedDate가 상대의 exitDate 이후일 때 : exitDate update
+		//      -> chatRoomRepository.updateExitDate(me);
+		else {
+			mine.setExitDate(new Date());
+			chatRoomService.update(chatRoom);
+		}
+	}
+
+    // TODO solomon : 유저정보 생성하기
+    public void createOrUpdateUser(RiotAccount riotAccount) {
+		User user = userService.save(riotAccount);
+
+		List<ChatRoom> chatRooms = chatRoomService.findChatRoom(user);
+		if (!chatRooms.isEmpty()) {
+			MessageResponse response = new MessageResponse(MessageType.USERINFO, new UserDto(user));
+			chatRooms.forEach(
+				chatRoom -> sendToChatRoomSubscribers(chatRoom.getChatRoomNo(), response));
+		}
+    }
+
+	public void createOrUpdateUser(List<RiotAccount> accounts){
+		List<User> users = accounts.stream().map(account-> User.toUser(account)).toList();
+
+		BulkWriteResult bulkWriteResult = userService.updateMany(users);
+	}
+
+	// TODO so1omon : 특정 유저와 채팅을 나눈 member id list 넘기기
+	public List<Long> getChattedMemberIds(Long id){
+
+		// 0. 유저 정보 검색
+		User me = userService.getUser(id);
+
+		// 1. 내 정보로 chatRoom 리스트 검색
+		List<ChatRoom> chatRooms = chatRoomService.findChatRoom(me);
+
+		// 2. chatRoom에 속해 있는 모든 other participants 정보 검색하여 Id 추출
+		List<Long> memberIds = chatRooms.stream().map(chatRoom ->
+			 getOther(me, chatRoom).getActualUserId()).toList();
+
+		// 3. return
+		return memberIds;
+	}
+
+
+    // 차단
+    public void updateBlockStatus(Long myActualId, Long otherActualId, Blocked status) {
+        // 1. 나와 상대가 속해 있는 채팅방을 찾기 (수정예정)
+		User me = userService.getUser(myActualId);
+		User other = userService.getUser(otherActualId);
+
+		ChatRoom chatRoom = chatRoomService.findChatRoom(me, other)
+			.orElseThrow(() -> new BaseException(ErrorCode.NOT_FOUND_CHAT_ROOM, "두 유저가 존재하는 채팅방이 존재하지 않습니다."));
+
+		// 2. 해당 채팅방의 participant 정보 수정 후 save
+		extractParticipant(me, chatRoom.getParticipants(), true).setBlockedStatus(status);
+
+		chatRoomService.update(chatRoom);
+
+		if (status == Blocked.BLOCK) {
+			exitChatRoom(me, chatRoom);
+		}
+    }
+
+
+   // TODO janguni : 유저가 차단했는지 확인
+	public boolean isBlockParticipant(ChatRoom chatRoom, User other) {
+		List<Participant> participants = chatRoom.getParticipants();
+		Participant participant = extractParticipant(other, participants, true);
+		return participant.getBlockedStatus().equals(Blocked.BLOCK);
+	}
+
+
+	// TODO janguni: 채팅방별 채팅 목록 불러오기 (exitDate < sendDate)
+	public List<ChatDto> getChatList(User me, Long chatRoomNo) {
+
+		// TODO: 시간 순서대로 오는건지 확인
+		List<Chat> totalChats = chatService.findChat(chatRoomNo);
+		Date exitDate = getExitDate(chatRoomNo, me);
+
+		return getChatDtoAfterExitDate(totalChats, exitDate);
+	}
+
+
+	// TODO janguni: 채팅 저장
+	public void sendChat(User user, Long chatRoomNo, String message) {
+		Date now = new Date();
+
+		ChatRoom chatRoom = chatRoomService.findChatRoom(chatRoomNo)
+			.orElseThrow(() -> new BaseException(ErrorCode.NOT_FOUND_CHAT_ROOM));
+
+		chatService.save(user, chatRoomNo, message, now);
+
+		chatRoom.setLastModifiedDate(now);
+		chatRoomService.update(chatRoom);
+	}
+
+	// TODO janguni: 접속정보 변동내역 전송
+	public void updateConnStatus(User user, Status connectStatus) {
+		user.setStatus(connectStatus);
+		userService.save(user);
+
+		List<ChatRoom> chatRooms = chatRoomService.findChatRoom(user);
+		MessageResponse response = new MessageResponse(MessageType.CONNECTSTATUS, connectStatus);
+
+		chatRooms.forEach(chatRoom ->
+			sendToChatRoomSubscribers(chatRoom.getChatRoomNo(), response));
+	}
+
+	// TODO janguni: 채팅방에 있는 상대방이 보낸 채팅의 readCount update
+	public void checkChatsInChatRoom(User me, Long chatRoomNo) {
+		ChatRoom chatRoom = chatRoomService.findChatRoom(chatRoomNo)
+			.orElseThrow(() -> new BaseException(ErrorCode.NOT_FOUND_CHAT_ROOM));
+
+		Long otherActualUserId = getOther(me, chatRoom).getActualUserId();
+
+		List<Chat> totalChats = chatService.findChat(chatRoomNo);
+
+		totalChats.stream()
+			.filter(chat -> (chat.getReadCnt() == 1 && chat.getSenderId().equals(otherActualUserId)))
+			.forEach(chat -> {
+				chat.setReadCnt(0);
+				chatService.save(chat);
+			});
+	}
+
+	public void sendToUserSubscribers(String userId, MessageResponse response){
+		template.convertAndSend("/sub/user/" + userId, response);
+	}
+
+	public void sendToChatRoomSubscribers(Long chatRoomId, MessageResponse response){
+		template.convertAndSend("/sub/chatRoom/" + chatRoomId, response);
+	}
+
+	private User getOther(User me, ChatRoom chatRoom) {
+		List<Participant> participants = chatRoom.getParticipants();
+		Participant participant = extractParticipant(me, participants, false);
+		User other = participant.getUser();
+		return other;
+	}
+
+
+	private List<ChatDto> getChatDtoAfterExitDate(List<Chat> totalChats, Date exitDate) {
+		return totalChats.stream()
+			.filter(chat -> exitDate == null || chat.getSendDate().after(exitDate))
+			.map(ChatDto::new)
+			.toList();
+	}
+
+
+	private Date getExitDate(Long chatRoomNo, User user) {
+		ChatRoom chatRoom = chatRoomService.getChatRoom(chatRoomNo);
+
+		return extractParticipant(user,chatRoom.getParticipants(), true)
+			.getExitDate();
+	}
+
+
+	/**isMe==true이면 Participant List에서 내 Participant 정보를 추출
+	 * isMe==false이면 other user에 해당하는 Participant 정보를 추출
+	 * @param me 자신의 유저정보
+	 * @param participants 추출할 대상이 되는 Participant
+	 * @param isMe 자신의 유저정보를 가져올 것인지 여부
+	 * @return Participant
+	 */
+	public Participant extractParticipant(User me, List<Participant> participants, Boolean isMe) {
+		int stdUserFoundedCnt = 0;
+		int stdUserIdx = 0;
+
+		//1. 나를 기준으로 participant 찾기
+		for(int i=0;i<2;i++){
+			Participant participant =participants.get(i);
+			if(participant.getUser().getActualUserId().equals(me.getActualUserId())){
+				stdUserFoundedCnt++;
+				stdUserIdx = i;
+			}
+		}
+
+		//2. 만약 내 유저 정보가 없다면 오류 반환
+		if(stdUserFoundedCnt!=2){
+			throw new BaseException(ErrorCode.INTERNAL_SERVER_ERROR, "Participants가 유효하지 않습니다.");
+		}
+
+		//3. isMe에 따라 return하기
+		return isMe ? participants.get(stdUserIdx) : participants.get(1-stdUserIdx);
+	}
+
+
+
+}

--- a/src/main/java/com/gnimty/communityapiserver/domain/chat/service/UserService.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/chat/service/UserService.java
@@ -1,16 +1,46 @@
 package com.gnimty.communityapiserver.domain.chat.service;
 
-/**
- * packageName    : com.gnimty.communityapiserver.domain.chat.service
- * fileName       : UserService
- * author         : solmin
- * date           : 11/4/23
- * description    :
- * ===========================================================
- * DATE              AUTHOR             NOTE
- * -----------------------------------------------------------
- * 11/4/23        solmin       최초 생성
- */
-public class UserService {
+import com.gnimty.communityapiserver.domain.chat.entity.User;
+import com.gnimty.communityapiserver.domain.chat.repository.User.UserRepository;
+import com.gnimty.communityapiserver.domain.riotaccount.entity.RiotAccount;
+import com.gnimty.communityapiserver.global.exception.BaseException;
+import com.gnimty.communityapiserver.global.exception.ErrorCode;
+import com.mongodb.bulk.BulkWriteResult;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
 
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class UserService {
+    private final UserRepository userRepository;
+
+    public List<User> findUser(){
+        return userRepository.findAll();
+    }
+
+    public Optional<User> findUser(Long actualUserId){
+        return userRepository.findByActualUserId(actualUserId);
+    }
+
+    public User getUser(Long actualUserId) {
+        return findUser(actualUserId)
+            .orElseThrow(()-> new BaseException(ErrorCode.NOT_FOUND_CHAT_USER));
+    }
+
+    public User save(RiotAccount riotAccount){
+        return userRepository.save(User.toUser(riotAccount));
+    }
+
+    public User save(User user){
+        return userRepository.save(user);
+    }
+
+    public BulkWriteResult updateMany(List<User> users) {
+        return userRepository.bulkUpdate(users);
+    }
 }

--- a/src/main/java/com/gnimty/communityapiserver/domain/chat/service/UserService.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/chat/service/UserService.java
@@ -1,0 +1,16 @@
+package com.gnimty.communityapiserver.domain.chat.service;
+
+/**
+ * packageName    : com.gnimty.communityapiserver.domain.chat.service
+ * fileName       : UserService
+ * author         : solmin
+ * date           : 11/4/23
+ * description    :
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * -----------------------------------------------------------
+ * 11/4/23        solmin       최초 생성
+ */
+public class UserService {
+
+}

--- a/src/main/java/com/gnimty/communityapiserver/domain/member/controller/MemberController.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/member/controller/MemberController.java
@@ -16,7 +16,8 @@ import static com.gnimty.communityapiserver.global.constant.ResponseMessage.SUCC
 import static org.springframework.http.HttpStatus.ACCEPTED;
 import static org.springframework.http.HttpStatus.OK;
 
-import com.gnimty.communityapiserver.domain.chat.service.ChatService;
+import com.gnimty.communityapiserver.domain.chat.service.StompService;
+import com.gnimty.communityapiserver.domain.chat.service.UserService;
 import com.gnimty.communityapiserver.domain.member.controller.dto.request.IntroductionUpdateRequest;
 import com.gnimty.communityapiserver.domain.member.controller.dto.request.MyProfileUpdateRequest;
 import com.gnimty.communityapiserver.domain.member.controller.dto.request.OauthLoginRequest;
@@ -54,14 +55,16 @@ public class MemberController {
 
 	private final MemberService memberService;
 	private final MemberReadService memberReadService;
-	private final ChatService chatService;
+	private final StompService stompService;
+	private final UserService userService;
+
 
 	@PostMapping("/{member_id}/rso")
 	public CommonResponse<Void> summonerAccountLink(
 		@RequestBody @Valid OauthLoginRequest request
 	) {
 		RiotAccount riotAccount = memberService.summonerAccountLink(request.toServiceRequest());
-		chatService.createOrUpdateUser(riotAccount);
+		stompService.createOrUpdateUser(riotAccount);
 		return CommonResponse.success(SUCCESS_SUMMONER_LINK, OK);
 	}
 
@@ -94,10 +97,10 @@ public class MemberController {
 	) {
 		RiotAccount riotAccount = memberService.updateMyProfile(memberId, request.toServiceRequest());
 		if (request.getStatus() != null) {
-			chatService.updateConnStatus(chatService.getUser(memberId), request.getStatus());
+			stompService.updateConnStatus(userService.getUser(memberId), request.getStatus());
 		}
 		if (riotAccount != null) {
-			chatService.createOrUpdateUser(riotAccount);
+			stompService.createOrUpdateUser(riotAccount);
 		}
 		return CommonResponse.success(SUCCESS_UPDATE_PROFILE, OK);
 	}
@@ -132,7 +135,7 @@ public class MemberController {
 		@RequestBody @Valid StatusUpdateRequest request
 	) {
 		memberService.updateStatus(memberId, request.toServiceRequest());
-		chatService.updateConnStatus(chatService.getUser(memberId), request.getStatus());
+		stompService.updateConnStatus(userService.getUser(memberId), request.getStatus());
 		return CommonResponse.success(SUCCESS_UPDATE_STATUS, OK);
 	}
 

--- a/src/test/java/com/gnimty/communityapiserver/domain/chat/service/StompServiceTest.java
+++ b/src/test/java/com/gnimty/communityapiserver/domain/chat/service/StompServiceTest.java
@@ -67,7 +67,7 @@ class StompServiceTest {
                     .division(3)
                     .summonerName("so1omon")
                     .status(Status.ONLINE)
-                    .lp(3L).build());
+                    .lp(3L).build()));
         }
 
         for (Integer i = 1; i < 10; i++) {
@@ -79,7 +79,7 @@ class StompServiceTest {
         for (Integer i = 11; i < 20; i++) {
             chatRooms.add(chatRoomService.save(
                 new UserWithBlockDto(users.get(10),Blocked.UNBLOCK),
-                new UserWithBlockDto(users.get(i),Blocked.UNBLOCK),));
+                new UserWithBlockDto(users.get(i),Blocked.UNBLOCK)));
         }
     }
 

--- a/src/test/java/com/gnimty/communityapiserver/domain/chat/service/StompServiceTest.java
+++ b/src/test/java/com/gnimty/communityapiserver/domain/chat/service/StompServiceTest.java
@@ -31,21 +31,21 @@ import org.springframework.test.context.ActiveProfiles;
 @Slf4j
 @SpringBootTest
 @ActiveProfiles("test")
-class ChatServiceTest {
+class StompServiceTest {
 
     @Autowired
     private SeqGeneratorService seqGeneratorService;
     @Autowired
+    private StompService stompService;
+    @Autowired
+    private UserService userService;
+    @Autowired
+    private ChatRoomService chatRoomService;
+    @Autowired
     private ChatService chatService;
+
     @Autowired
     private MongoTemplate mongoTemplate;
-    @Autowired
-    private ChatRepository chatRepository;
-    @Autowired
-    private UserRepository userRepository;
-    @Autowired
-    private ChatRoomRepository chatRoomRepository;
-
 
     void clear() {
         mongoTemplate.remove(new Query(), "chatRoom");
@@ -60,23 +60,26 @@ class ChatServiceTest {
         List<ChatRoom> chatRooms = new ArrayList<>();
 //
         for (Integer i = 0; i < 20; i++) {
-            users.add(userRepository.save(
-                new User(null, i.longValue(), 3L, Tier.DIAMOND, 3,
-                    "so1omon", Status.ONLINE)));
+            users.add(userService.save(
+                User.builder()
+                    .actualUserId(i.longValue())
+                    .tier(Tier.DIAMOND)
+                    .division(3)
+                    .summonerName("so1omon")
+                    .status(Status.ONLINE)
+                    .lp(3L).build());
         }
 
         for (Integer i = 1; i < 10; i++) {
-            chatRooms.add(chatRoomRepository.save(
+            chatRooms.add(chatRoomService.save(
                 new UserWithBlockDto(users.get(0),Blocked.UNBLOCK),
-                new UserWithBlockDto(users.get(i),Blocked.UNBLOCK),
-                seqGeneratorService.generateSequence(ChatRoom.SEQUENCE_NAME)));
+                new UserWithBlockDto(users.get(i),Blocked.UNBLOCK)));
         }
 
         for (Integer i = 11; i < 20; i++) {
-            chatRooms.add(chatRoomRepository.save(
+            chatRooms.add(chatRoomService.save(
                 new UserWithBlockDto(users.get(10),Blocked.UNBLOCK),
-                new UserWithBlockDto(users.get(i),Blocked.UNBLOCK),
-                seqGeneratorService.generateSequence(ChatRoom.SEQUENCE_NAME)));
+                new UserWithBlockDto(users.get(i),Blocked.UNBLOCK),));
         }
     }
 
@@ -90,7 +93,7 @@ class ChatServiceTest {
     void getUser_테스트() {
         // 1L부터 20L에 해당하는 유저가 존재해야 함
         for (Integer i = 0; i < 20; i++) {
-            User user = chatService.getUser(i.longValue());
+            User user = userService.getUser(i.longValue());
 
             System.out.println("user = " + user);
         }
@@ -98,8 +101,8 @@ class ChatServiceTest {
 
     @Test
     void getChatRoomsJoined_테스트() {
-        User me = userRepository.findByActualUserId(10L).get();
-        List<ChatRoomDto> chatRoomsJoined = chatService.getChatRoomsJoined(me);
+        User me = userService.getUser(10L);
+        List<ChatRoomDto> chatRoomsJoined = stompService.getChatRoomsJoined(me);
 
         for (ChatRoomDto chatRoomDto : chatRoomsJoined) {
             System.out.printf("chatRoomId = %d, otherUserId = %d\n",
@@ -110,18 +113,18 @@ class ChatServiceTest {
 
     @Test
     void getOrCreateChatRoom_테스트() {
-        List<User> all = userRepository.findAll();
+        List<User> all = userService.findUser();
 
-        List<ChatRoom> chatRooms = chatRoomRepository.findByUser(all.get(0));
+        List<ChatRoom> chatRooms = chatRoomService.findChatRoom(all.get(0));
         // 이미 존재하는 유저 쌍(0, 1번 유저)은 호출 시 기존 chatRoom인 첫 번째 chatRoom과 같음
-        ChatRoomDto chatRoomDto1 = chatService.getOrCreateChatRoomDto(
+        ChatRoomDto chatRoomDto1 = stompService.getOrCreateChatRoomDto(
             new UserWithBlockDto(all.get(0), Blocked.UNBLOCK),
             new UserWithBlockDto(all.get(1), Blocked.UNBLOCK)
         );
         assertThat(chatRooms.get(0).getChatRoomNo()).isEqualTo(chatRoomDto1.getChatRoomNo());
         // 새로운 유저 쌍 생성
 
-        ChatRoomDto chatRoomDto2 = chatService.getOrCreateChatRoomDto(
+        ChatRoomDto chatRoomDto2 = stompService.getOrCreateChatRoomDto(
             new UserWithBlockDto(all.get(1), Blocked.UNBLOCK),
             new UserWithBlockDto(all.get(2), Blocked.UNBLOCK));
         assertThat(chatRoomDto2.getChatRoomNo()).isEqualTo(19);
@@ -137,16 +140,16 @@ class ChatServiceTest {
     void isBlockParticipant_테스트() {
         // given
         //      유저 2명
-        User user1 = userRepository.findByActualUserId(0L).get();
-        User user2 = userRepository.findByActualUserId(1L).get();
+        User user1 = userService.getUser(0L);
+        User user2 = userService.getUser(1L);
 
         //      user1이 user2를 차단
         ChatRoom chatRoom = block(user1, user2);
 
 
         // when
-        boolean result1 = chatService.isBlockParticipant(chatRoom, user1);
-        boolean result2 = chatService.isBlockParticipant(chatRoom, user2);
+        boolean result1 = stompService.isBlockParticipant(chatRoom, user1);
+        boolean result2 = stompService.isBlockParticipant(chatRoom, user2);
 
 
         // then
@@ -158,18 +161,18 @@ class ChatServiceTest {
     void saveChat_테스트() throws InterruptedException {
 
         // given
-        User user = userRepository.findByActualUserId(0L).get();
-        ChatRoom chatRoom = chatRoomRepository.findByChatRoomNo(1L).get();
+        User user = userService.getUser(0L);
+        ChatRoom chatRoom = chatRoomService.getChatRoom(1L);
         Date originLastModifiedDate = chatRoom.getLastModifiedDate();
         String message = "안녕하세요";
 
         // when
         sleep(3000);
-        chatService.saveChat(user, chatRoom.getChatRoomNo(), message);
+        stompService.sendChat(user, chatRoom.getChatRoomNo(), message);
 
         // then
-        List<Chat> chats = chatRepository.findByChatRoomNo(chatRoom.getChatRoomNo());
-        ChatRoom updatedChatRoom = chatRoomRepository.findByChatRoomNo(chatRoom.getChatRoomNo()).get();
+        List<Chat> chats = chatService.findChat(chatRoom.getChatRoomNo());
+        ChatRoom updatedChatRoom = chatRoomService.getChatRoom(chatRoom.getChatRoomNo());
         assertThat(chats.size()).isEqualTo(1);
         assertThat(originLastModifiedDate).isBefore(updatedChatRoom.getLastModifiedDate());
     }
@@ -177,13 +180,13 @@ class ChatServiceTest {
     @Test
     void updateConnStatus_테스트() {
         // given
-        User user = userRepository.findByActualUserId(0L).get();
+        User user = userService.getUser(0L);
 
         // when
-        chatService.updateConnStatus(user, Status.AWAY);
+        stompService.updateConnStatus(user, Status.AWAY);
 
         // then
-        User updatedUser = userRepository.findByActualUserId(0L).get();
+        User updatedUser = userService.getUser(0L);
         assertThat(updatedUser.getStatus()).isEqualTo(Status.AWAY);
     }
 
@@ -191,33 +194,31 @@ class ChatServiceTest {
     void checkChatsInChatRoom_테스트() {
         // given
         //      유저 2명
-        User user1 = userRepository.findByActualUserId(0L).get();
-        User user2 = userRepository.findByActualUserId(1L).get();
+        User user1 = userService.getUser(0L);
+        User user2 = userService.getUser(1L);
 
         //      채팅방
-        ChatRoom chatRoom = chatRoomRepository.findByUsers(user1, user2).get();
+        ChatRoom chatRoom = chatRoomService.getChatRoom(user1, user2);
 
         //      user2가 읽지 않은 채팅 5개
         for (int i = 0; i < 5; i++) {
-            Chat chat = new Chat(chatRoom.getChatRoomNo(), user1.getActualUserId(), "hi",
-                new Date(), 1);
-            chatRepository.save(chat);
+            Chat chat = new Chat(chatRoom.getChatRoomNo(), user1.getActualUserId(), "hi", new Date());
+            chatService.save(chat);
         }
 
         //      user1가 읽지 않은 채팅 5개
         for (int i = 0; i < 5; i++) {
-            Chat chat = new Chat(chatRoom.getChatRoomNo(), user2.getActualUserId(), "hello",
-                new Date(), 1);
-            chatRepository.save(chat);
+            Chat chat = new Chat(chatRoom.getChatRoomNo(), user2.getActualUserId(), "hello", new Date());
+            chatService.save(chat);
         }
 
 
         // when
-        chatService.checkChatsInChatRoom(user2, chatRoom.getChatRoomNo()); // user2가 채팅방 읽음
+        stompService.checkChatsInChatRoom(user2, chatRoom.getChatRoomNo()); // user2가 채팅방 읽음
 
 
         // then
-        List<Chat> chats = chatRepository.findByChatRoomNo(chatRoom.getChatRoomNo());
+        List<Chat> chats = chatService.findChat(chatRoom.getChatRoomNo());
         for (Chat chat : chats) {
             if (chat.getSenderId().equals(user1.getActualUserId())) {
                 assertThat(chat.getReadCnt()).isEqualTo(0);
@@ -229,7 +230,7 @@ class ChatServiceTest {
 
 
     private ChatRoom block(User user1, User user2) {
-        ChatRoom chatRoom = chatRoomRepository.findByUsers(user1, user2).get();
+        ChatRoom chatRoom = chatRoomService.getChatRoom(user1, user2);
         List<Participant> originParticipants = chatRoom.getParticipants();
 
         List<Participant> updateParticipants = new ArrayList<>();
@@ -241,7 +242,7 @@ class ChatServiceTest {
         updateParticipants.add(participant1);
         updateParticipants.add(participant2);
         chatRoom.setParticipants(updateParticipants);
-        chatRoomRepository.save(chatRoom);
+        chatRoomService.update(chatRoom);
         return chatRoom;
     }
 
@@ -249,22 +250,21 @@ class ChatServiceTest {
     void getChatList_테스트() {
         // given
         //      유저 2명
-        User user1 = userRepository.findByActualUserId(0L).get();
-        User user2 = userRepository.findByActualUserId(1L).get();
+        User user1 = userService.getUser(0L);
+        User user2 = userService.getUser(1L);
 
         //      채팅방
-        ChatRoom chatRoom = chatRoomRepository.findByUsers(user1, user2).get();
+        ChatRoom chatRoom = chatRoomService.getChatRoom(user1, user2);
 
         // when
         //      2번 채팅 -> user2가 나감 -> 3번 채팅(user1)
         for (int i = 0; i < 2; i++) {
             Chat chat = Chat.builder()
                 .chatRoomNo(chatRoom.getChatRoomNo())
-                .readCnt(1)
                 .senderId(user1.getActualUserId())
                 .sendDate(new Date())
                 .message("hi").build();
-            chatRepository.save(chat);
+            chatService.save(chat);
         }
 
         quitRoom(chatRoom);
@@ -272,17 +272,16 @@ class ChatServiceTest {
         for (int i = 0; i < 3; i++) {
             Chat chat = Chat.builder()
                 .chatRoomNo(chatRoom.getChatRoomNo())
-                .readCnt(1)
                 .senderId(user1.getActualUserId())
                 .sendDate(new Date())
                 .message("hi").build();
-            chatRepository.save(chat);
+            chatService.save(chat);
         }
 
         // then
-        List<ChatDto> chatList1 = chatService.getChatList(user2, chatRoom.getChatRoomNo());
+        List<ChatDto> chatList1 = stompService.getChatList(user2, chatRoom.getChatRoomNo());
         assertThat(chatList1.size()).isEqualTo(3);
-        List<ChatDto> chatList2 = chatService.getChatList(user1, chatRoom.getChatRoomNo());
+        List<ChatDto> chatList2 = stompService.getChatList(user1, chatRoom.getChatRoomNo());
         assertThat(chatList2.size()).isEqualTo(5);
     }
 
@@ -296,7 +295,7 @@ class ChatServiceTest {
         participants.add(participant1);
         participants.add(participant2);
         chatRoom.setParticipants(participants);
-        chatRoomRepository.save(chatRoom);
+        chatRoomService.update(chatRoom);
     }
 
 }


### PR DESCRIPTION
1. 기존의 ChatService를 최상위 서비스 StompService -> 각 도메인의 레포지토리를 의존하는 UserService, ChatService, ChatRoomService로 분리
2. Optional<T> orElseGet 관련 boilerplate methods들을 없애기 위하여 get~() method와 find~() method 분리 
find vs get → find는 List로 찾거나 Optional Data 조회 시, get은 반드시 단일 유저정보를 조회함과 동시에 존재하지 않으면 Exception
3. 버그 수정 

-closes #43 