### PR TITLE
Fix/#52 비밀번호 변경, 수정 api 분리

### DIFF
--- a/src/main/java/com/gnimty/communityapiserver/domain/member/controller/MemberController.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/member/controller/MemberController.java
@@ -11,7 +11,6 @@ import static com.gnimty.communityapiserver.global.constant.ResponseMessage.SUCC
 import static com.gnimty.communityapiserver.global.constant.ResponseMessage.SUCCESS_UPDATE_PREFER_GAME_MODE;
 import static com.gnimty.communityapiserver.global.constant.ResponseMessage.SUCCESS_UPDATE_PROFILE;
 import static com.gnimty.communityapiserver.global.constant.ResponseMessage.SUCCESS_UPDATE_STATUS;
-import static com.gnimty.communityapiserver.global.constant.ResponseMessage.SUCCESS_VERIFY_EMAIL;
 import static com.gnimty.communityapiserver.global.constant.ResponseMessage.SUCCESS_WITHDRAWAL;
 import static org.springframework.http.HttpStatus.ACCEPTED;
 import static org.springframework.http.HttpStatus.OK;
@@ -22,15 +21,19 @@ import com.gnimty.communityapiserver.domain.member.controller.dto.request.Introd
 import com.gnimty.communityapiserver.domain.member.controller.dto.request.MyProfileUpdateRequest;
 import com.gnimty.communityapiserver.domain.member.controller.dto.request.OauthLoginRequest;
 import com.gnimty.communityapiserver.domain.member.controller.dto.request.PasswordEmailVerifyRequest;
+import com.gnimty.communityapiserver.domain.member.controller.dto.request.PasswordResetRequest;
 import com.gnimty.communityapiserver.domain.member.controller.dto.request.PasswordUpdateRequest;
 import com.gnimty.communityapiserver.domain.member.controller.dto.request.PreferGameModeUpdateRequest;
+import com.gnimty.communityapiserver.domain.member.controller.dto.request.SendEmailRequest;
 import com.gnimty.communityapiserver.domain.member.controller.dto.request.StatusUpdateRequest;
 import com.gnimty.communityapiserver.domain.member.controller.dto.response.MyProfileResponse;
 import com.gnimty.communityapiserver.domain.member.controller.dto.response.OtherProfileResponse;
+import com.gnimty.communityapiserver.domain.member.controller.dto.response.PasswordEmailVerifyResponse;
 import com.gnimty.communityapiserver.domain.member.service.MemberReadService;
 import com.gnimty.communityapiserver.domain.member.service.MemberService;
 import com.gnimty.communityapiserver.domain.member.service.dto.response.MyProfileServiceResponse;
 import com.gnimty.communityapiserver.domain.member.service.dto.response.OtherProfileServiceResponse;
+import com.gnimty.communityapiserver.domain.member.service.dto.response.PasswordEmailVerifyServiceResponse;
 import com.gnimty.communityapiserver.domain.riotaccount.entity.RiotAccount;
 import com.gnimty.communityapiserver.global.constant.Provider;
 import com.gnimty.communityapiserver.global.response.CommonResponse;
@@ -105,19 +108,27 @@ public class MemberController {
 	}
 
 	@ResponseStatus(ACCEPTED)
-	@PostMapping("/{member_id}/password/email")
-	public CommonResponse<Void> sendEmailAuthCode() {
-		memberService.sendEmailAuthCode();
+	@PostMapping("/password/email")
+	public CommonResponse<Void> sendEmailAuthCode(@RequestBody @Valid SendEmailRequest request) {
+		memberService.sendEmailAuthCode(request.toServiceRequest());
 		return CommonResponse.success(SUCCESS_SEND_EMAIL_AUTH_CODE, ACCEPTED);
 	}
 
-	@PostMapping("/{member_id}/password/email/code")
-	public CommonResponse<Void> verifyEmailAuthCode(
+	@PostMapping("/password/email/code")
+	public CommonResponse<PasswordEmailVerifyResponse> verifyEmailAuthCode(
 		@RequestBody @Valid PasswordEmailVerifyRequest request
 	) {
-		memberService.verifyEmailAuthCode(request.toServiceRequest());
-		return CommonResponse.success(SUCCESS_VERIFY_EMAIL, OK);
+		PasswordEmailVerifyServiceResponse response = memberService.verifyEmailAuthCode(
+			request.toServiceRequest());
+		return CommonResponse.success(PasswordEmailVerifyResponse.from(response));
 	}
+
+	@PatchMapping("/password")
+	public CommonResponse<Void> resetPassword(@RequestBody @Valid PasswordResetRequest request) {
+		memberService.resetPassword(request.toServiceRequest());
+		return CommonResponse.success(SUCCESS_UPDATE_PASSWORD, OK);
+	}
+
 
 	@PatchMapping("/{member_id}/password")
 	public CommonResponse<Void> updatePassword(

--- a/src/main/java/com/gnimty/communityapiserver/domain/member/controller/dto/request/PasswordEmailVerifyRequest.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/member/controller/dto/request/PasswordEmailVerifyRequest.java
@@ -18,11 +18,16 @@ import lombok.NoArgsConstructor;
 public class PasswordEmailVerifyRequest {
 
 	@NotNull(message = INVALID_INPUT_VALUE)
+	@Pattern(regexp = RequestPattern.EMAIL_PATTERN, message = INVALID_INPUT_VALUE)
+	private String email;
+
+	@NotNull(message = INVALID_INPUT_VALUE)
 	@Pattern(regexp = RequestPattern.EMAIL_AUTH_CODE_PATTERN, message = INVALID_INPUT_VALUE)
 	private String code;
 
 	public PasswordEmailVerifyServiceRequest toServiceRequest() {
 		return PasswordEmailVerifyServiceRequest.builder()
+			.email(email)
 			.code(code)
 			.build();
 	}

--- a/src/main/java/com/gnimty/communityapiserver/domain/member/controller/dto/request/PasswordResetRequest.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/member/controller/dto/request/PasswordResetRequest.java
@@ -1,0 +1,37 @@
+package com.gnimty.communityapiserver.domain.member.controller.dto.request;
+
+import com.gnimty.communityapiserver.domain.member.service.dto.request.PasswordResetServiceRequest;
+import com.gnimty.communityapiserver.global.constant.RequestPattern;
+import com.gnimty.communityapiserver.global.exception.ErrorCode.ErrorMessage;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PasswordResetRequest {
+
+	@NotNull(message = ErrorMessage.INVALID_INPUT_VALUE)
+	@Pattern(regexp = RequestPattern.EMAIL_PATTERN, message = ErrorMessage.INVALID_INPUT_VALUE)
+	private String email;
+
+	@NotNull(message = ErrorMessage.INVALID_INPUT_VALUE)
+	@Pattern(regexp = RequestPattern.PASSWORD_PATTERN, message = ErrorMessage.INVALID_INPUT_VALUE)
+	private String password;
+
+	@NotNull(message = ErrorMessage.INVALID_INPUT_VALUE)
+	private String uuid;
+
+	public PasswordResetServiceRequest toServiceRequest() {
+		return PasswordResetServiceRequest.builder()
+			.email(email)
+			.password(password)
+			.uuid(uuid)
+			.build();
+	}
+}

--- a/src/main/java/com/gnimty/communityapiserver/domain/member/controller/dto/request/PasswordUpdateRequest.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/member/controller/dto/request/PasswordUpdateRequest.java
@@ -18,11 +18,16 @@ public class PasswordUpdateRequest {
 
 	@NotNull(message = ErrorMessage.INVALID_INPUT_VALUE)
 	@Pattern(regexp = RequestPattern.PASSWORD_PATTERN, message = ErrorMessage.INVALID_INPUT_VALUE)
-	private String password;
+	private String currentPassword;
+
+	@NotNull(message = ErrorMessage.INVALID_INPUT_VALUE)
+	@Pattern(regexp = RequestPattern.PASSWORD_PATTERN, message = ErrorMessage.INVALID_INPUT_VALUE)
+	private String newPassword;
 
 	public PasswordUpdateServiceRequest toServiceRequest() {
 		return PasswordUpdateServiceRequest.builder()
-			.password(password)
+			.currentPassword(currentPassword)
+			.newPassword(newPassword)
 			.build();
 	}
 }

--- a/src/main/java/com/gnimty/communityapiserver/domain/member/controller/dto/request/SendEmailRequest.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/member/controller/dto/request/SendEmailRequest.java
@@ -1,6 +1,8 @@
 package com.gnimty.communityapiserver.domain.member.controller.dto.request;
 
 import com.gnimty.communityapiserver.domain.member.service.dto.request.SendEmailServiceRequest;
+import com.gnimty.communityapiserver.global.exception.ErrorCode.ErrorMessage;
+import javax.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,6 +14,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class SendEmailRequest {
 
+	@NotNull(message = ErrorMessage.INVALID_INPUT_VALUE)
 	private String email;
 
 	public SendEmailServiceRequest toServiceRequest() {

--- a/src/main/java/com/gnimty/communityapiserver/domain/member/controller/dto/request/SendEmailRequest.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/member/controller/dto/request/SendEmailRequest.java
@@ -1,0 +1,22 @@
+package com.gnimty.communityapiserver.domain.member.controller.dto.request;
+
+import com.gnimty.communityapiserver.domain.member.service.dto.request.SendEmailServiceRequest;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SendEmailRequest {
+
+	private String email;
+
+	public SendEmailServiceRequest toServiceRequest() {
+		return SendEmailServiceRequest.builder()
+			.email(email)
+			.build();
+	}
+}

--- a/src/main/java/com/gnimty/communityapiserver/domain/member/controller/dto/request/SendEmailRequest.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/member/controller/dto/request/SendEmailRequest.java
@@ -1,8 +1,10 @@
 package com.gnimty.communityapiserver.domain.member.controller.dto.request;
 
 import com.gnimty.communityapiserver.domain.member.service.dto.request.SendEmailServiceRequest;
+import com.gnimty.communityapiserver.global.constant.RequestPattern;
 import com.gnimty.communityapiserver.global.exception.ErrorCode.ErrorMessage;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,6 +17,7 @@ import lombok.NoArgsConstructor;
 public class SendEmailRequest {
 
 	@NotNull(message = ErrorMessage.INVALID_INPUT_VALUE)
+	@Pattern(regexp = RequestPattern.EMAIL_PATTERN, message = ErrorMessage.INVALID_INPUT_VALUE)
 	private String email;
 
 	public SendEmailServiceRequest toServiceRequest() {

--- a/src/main/java/com/gnimty/communityapiserver/domain/member/controller/dto/response/PasswordEmailVerifyResponse.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/member/controller/dto/response/PasswordEmailVerifyResponse.java
@@ -1,0 +1,18 @@
+package com.gnimty.communityapiserver.domain.member.controller.dto.response;
+
+import com.gnimty.communityapiserver.domain.member.service.dto.response.PasswordEmailVerifyServiceResponse;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class PasswordEmailVerifyResponse {
+
+	private String uuid;
+
+	public static PasswordEmailVerifyResponse from(PasswordEmailVerifyServiceResponse response) {
+		return PasswordEmailVerifyResponse.builder()
+			.uuid(response.getUuid())
+			.build();
+	}
+}

--- a/src/main/java/com/gnimty/communityapiserver/domain/member/service/AuthService.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/member/service/AuthService.java
@@ -69,7 +69,8 @@ public class AuthService {
 	}
 
 	public AuthToken login(LoginServiceRequest request) {
-		Member member = memberReadService.findByEmailOrElseThrow(request.getEmail());
+		Member member = memberReadService.findByEmailOrElseThrow(request.getEmail(),
+			new BaseException(ErrorCode.INVALID_LOGIN));
 		throwIfMismatchPassword(request.getPassword(), member.getPassword());
 
 		AuthToken authToken = generateTokenPair(member.getId());

--- a/src/main/java/com/gnimty/communityapiserver/domain/member/service/MemberReadService.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/member/service/MemberReadService.java
@@ -27,9 +27,9 @@ public class MemberReadService {
 		}
 	}
 
-	public Member findByEmailOrElseThrow(String email) {
+	public Member findByEmailOrElseThrow(String email, BaseException exception) {
 		return memberRepository.findByEmail(email)
-			.orElseThrow(() -> new BaseException(ErrorCode.INVALID_LOGIN));
+			.orElseThrow(() -> exception);
 	}
 
 	public Member findById(Long id) {

--- a/src/main/java/com/gnimty/communityapiserver/domain/member/service/MemberService.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/member/service/MemberService.java
@@ -2,7 +2,6 @@ package com.gnimty.communityapiserver.domain.member.service;
 
 import static com.gnimty.communityapiserver.global.constant.KeyPrefix.PASSWORD;
 import static com.gnimty.communityapiserver.global.constant.KeyPrefix.REFRESH;
-import static com.gnimty.communityapiserver.global.constant.KeyPrefix.SIGNUP;
 import static com.gnimty.communityapiserver.global.constant.KeyPrefix.UPDATE_PASSWORD;
 
 import com.gnimty.communityapiserver.domain.block.repository.BlockRepository;
@@ -15,12 +14,15 @@ import com.gnimty.communityapiserver.domain.member.service.dto.request.Introduct
 import com.gnimty.communityapiserver.domain.member.service.dto.request.MyProfileUpdateServiceRequest;
 import com.gnimty.communityapiserver.domain.member.service.dto.request.OauthLoginServiceRequest;
 import com.gnimty.communityapiserver.domain.member.service.dto.request.PasswordEmailVerifyServiceRequest;
+import com.gnimty.communityapiserver.domain.member.service.dto.request.PasswordResetServiceRequest;
 import com.gnimty.communityapiserver.domain.member.service.dto.request.PasswordUpdateServiceRequest;
 import com.gnimty.communityapiserver.domain.member.service.dto.request.PreferGameModeUpdateServiceRequest;
+import com.gnimty.communityapiserver.domain.member.service.dto.request.SendEmailServiceRequest;
 import com.gnimty.communityapiserver.domain.member.service.dto.request.StatusUpdateServiceRequest;
 import com.gnimty.communityapiserver.domain.member.service.dto.response.IntroductionEntry;
 import com.gnimty.communityapiserver.domain.member.service.dto.response.MyProfileServiceResponse;
 import com.gnimty.communityapiserver.domain.member.service.dto.response.OauthInfoEntry;
+import com.gnimty.communityapiserver.domain.member.service.dto.response.PasswordEmailVerifyServiceResponse;
 import com.gnimty.communityapiserver.domain.member.service.dto.response.PreferGameModeEntry;
 import com.gnimty.communityapiserver.domain.member.service.dto.response.RiotAccountEntry;
 import com.gnimty.communityapiserver.domain.member.service.dto.response.RiotDependentInfo;
@@ -56,6 +58,7 @@ import com.gnimty.communityapiserver.global.exception.ErrorCode;
 import com.gnimty.communityapiserver.global.utils.RandomCodeGenerator;
 import java.util.List;
 import java.util.Objects;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -103,20 +106,20 @@ public class MemberService {
 		Boolean existsMain = riotAccountReadService.existsByMemberId(member);
 
 		RiotAccount riotAccount = riotAccountRepository.save(RiotAccount.builder()
-				.summonerName("summonerName")
-				.isMain(!existsMain)
-				.queue(Tier.BRONZE)
-				.lp(100L)
-				.division(100)
-				.mmr(100L)
-				.frequentLane1(Lane.TOP)
-				.frequentLane2(Lane.BOTTOM)
-				.frequentChampionId1(1L)
-				.frequentChampionId2(1L)
-				.frequentChampionId3(1L)
-				.puuid(puuid)
-				.member(member)
-				.build()
+			.summonerName("summonerName")
+			.isMain(!existsMain)
+			.queue(Tier.BRONZE)
+			.lp(100L)
+			.division(100)
+			.mmr(100L)
+			.frequentLane1(Lane.TOP)
+			.frequentLane2(Lane.BOTTOM)
+			.frequentChampionId1(1L)
+			.frequentChampionId2(1L)
+			.frequentChampionId3(1L)
+			.puuid(puuid)
+			.member(member)
+			.build()
 		);
 
 		if (!existsMain) {
@@ -171,51 +174,64 @@ public class MemberService {
 		return riotAccount;
 	}
 
-	public void sendEmailAuthCode() {
-		Member member = MemberThreadLocal.get();
+	public void sendEmailAuthCode(SendEmailServiceRequest request) {
+		Member member = memberReadService.findByEmailOrElseThrow(
+			request.getEmail(), new BaseException(ErrorCode.NOT_LOGIN_BY_FORM));
 		if (member.getEmail() == null) {
 			throw new BaseException(ErrorCode.NOT_LOGIN_BY_FORM);
 		}
-		sendEmail(member);
-	}
-
-	@Async("mailExecutor")
-	public void sendEmail(Member member) {
 		String code = RandomCodeGenerator.generateCodeByLength(6);
-		mailSenderUtil.sendEmail(Auth.EMAIL_SUBJECT.getContent(), member.getEmail(), code,
-			"password-mail", "static/images/banner-urf.png");
-		String key = getRedisKey(PASSWORD, String.valueOf(member.getId()));
+		sendEmail(member, code);
+		String key = getRedisKey(PASSWORD, member.getEmail());
 		saveInRedis(key, code, Auth.EMAIL_CODE_EXPIRATION.getExpiration());
 	}
 
-	public void verifyEmailAuthCode(PasswordEmailVerifyServiceRequest request) {
-		Member member = MemberThreadLocal.get();
+	@Async("mailExecutor")
+	public void sendEmail(Member member, String code) {
+		mailSenderUtil.sendEmail(Auth.EMAIL_SUBJECT.getContent(), member.getEmail(), code,
+			"password-mail", "static/images/banner-urf.png");
+	}
+
+	public PasswordEmailVerifyServiceResponse verifyEmailAuthCode(
+		PasswordEmailVerifyServiceRequest request) {
 		ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
 
-		String emailAuthKey = getRedisKey(PASSWORD, String.valueOf(member.getId()));
+		String emailAuthKey = getRedisKey(PASSWORD, request.getEmail());
 		String savedCode = valueOperations.get(emailAuthKey);
 
 		if (!request.getCode().equals(savedCode)) {
 			throw new BaseException(ErrorCode.INVALID_EMAIL_AUTH_CODE);
 		}
-		String passwordKey = getRedisKey(UPDATE_PASSWORD, String.valueOf(member.getId()));
-		saveInRedis(passwordKey, "verified", Auth.PASSWORD_EXPIRATION.getExpiration());
+		UUID uuid = UUID.randomUUID();
+		String passwordKey = getRedisKey(UPDATE_PASSWORD, request.getEmail());
+		saveInRedis(passwordKey, uuid.toString(), Auth.PASSWORD_EXPIRATION.getExpiration());
 		valueOperations.getAndDelete(emailAuthKey);
+		return PasswordEmailVerifyServiceResponse.builder()
+			.uuid(uuid.toString())
+			.build();
+	}
+
+	public void resetPassword(PasswordResetServiceRequest request) {
+		ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+
+		String uuid = valueOperations.get(getRedisKey(UPDATE_PASSWORD, request.getEmail()));
+		if (!request.getUuid().equals(uuid)) {
+			throw new BaseException(ErrorCode.UNAUTHORIZED_EMAIL);
+		}
+		Member member = memberReadService.findByEmailOrElseThrow(request.getEmail(),
+			new BaseException(ErrorCode.NOT_LOGIN_BY_FORM));
+		member.updatePassword(request.getPassword());
+
+		redisTemplate.delete(getRedisKey(UPDATE_PASSWORD, request.getEmail()));
 	}
 
 	public void updatePassword(Long memberId, PasswordUpdateServiceRequest request) {
 		Member member = memberReadService.findById(memberId);
-		ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
-		String verify = valueOperations.get(
-			getRedisKey(SIGNUP, String.valueOf(member.getId())));
-		if (verify == null) {
-			throw new BaseException(ErrorCode.UNAUTHORIZED_EMAIL);
+		if (passwordEncoder.matches(request.getCurrentPassword(), member.getPassword())) {
+			throw new BaseException(ErrorCode.INVALID_PASSWORD);
 		}
-		member.updatePassword(passwordEncoder.encode(request.getPassword()));
+		member.updatePassword(passwordEncoder.encode(request.getNewPassword()));
 		memberRepository.save(member);
-
-		redisTemplate.delete(
-			getRedisKey(UPDATE_PASSWORD, String.valueOf(member.getId())));
 	}
 
 	public void updateStatus(Long memberId, StatusUpdateServiceRequest request) {
@@ -352,7 +368,8 @@ public class MemberService {
 		}
 	}
 
-	private RiotAccount updateMainRiotAccount(MyProfileUpdateServiceRequest request, Member member) {
+	private RiotAccount updateMainRiotAccount(MyProfileUpdateServiceRequest request,
+		Member member) {
 		if (request.getMainRiotAccountId() != null) {
 			RiotAccount prevMainAccount = riotAccountReadService.findMainAccountByMember(
 				member);

--- a/src/main/java/com/gnimty/communityapiserver/domain/member/service/MemberService.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/member/service/MemberService.java
@@ -212,7 +212,7 @@ public class MemberService {
 
 		String uuid = valueOperations.get(getRedisKey(UPDATE_PASSWORD, request.getEmail()));
 		if (!request.getUuid().equals(uuid)) {
-			throw new BaseException(ErrorCode.UNAUTHORIZED_EMAIL);
+			throw new BaseException(ErrorCode.INVALID_UUID);
 		}
 		Member member = memberReadService.findByEmailOrElseThrow(request.getEmail(),
 			new BaseException(ErrorCode.NOT_LOGIN_BY_FORM));

--- a/src/main/java/com/gnimty/communityapiserver/domain/member/service/dto/request/PasswordEmailVerifyServiceRequest.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/member/service/dto/request/PasswordEmailVerifyServiceRequest.java
@@ -7,5 +7,6 @@ import lombok.Getter;
 @Getter
 public class PasswordEmailVerifyServiceRequest {
 
+	private String email;
 	private String code;
 }

--- a/src/main/java/com/gnimty/communityapiserver/domain/member/service/dto/request/PasswordResetServiceRequest.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/member/service/dto/request/PasswordResetServiceRequest.java
@@ -1,0 +1,13 @@
+package com.gnimty.communityapiserver.domain.member.service.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class PasswordResetServiceRequest {
+
+	private String email;
+	private String password;
+	private String uuid;
+}

--- a/src/main/java/com/gnimty/communityapiserver/domain/member/service/dto/request/PasswordUpdateServiceRequest.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/member/service/dto/request/PasswordUpdateServiceRequest.java
@@ -7,5 +7,6 @@ import lombok.Getter;
 @Getter
 public class PasswordUpdateServiceRequest {
 
-	private String password;
+	private String currentPassword;
+	private String newPassword;
 }

--- a/src/main/java/com/gnimty/communityapiserver/domain/member/service/dto/request/SendEmailServiceRequest.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/member/service/dto/request/SendEmailServiceRequest.java
@@ -1,0 +1,15 @@
+package com.gnimty.communityapiserver.domain.member.service.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SendEmailServiceRequest {
+
+	private String email;
+}

--- a/src/main/java/com/gnimty/communityapiserver/domain/member/service/dto/response/PasswordEmailVerifyServiceResponse.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/member/service/dto/response/PasswordEmailVerifyServiceResponse.java
@@ -1,0 +1,11 @@
+package com.gnimty.communityapiserver.domain.member.service.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class PasswordEmailVerifyServiceResponse {
+
+	private String uuid;
+}

--- a/src/main/java/com/gnimty/communityapiserver/domain/member/service/utils/MailSenderUtil.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/member/service/utils/MailSenderUtil.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.thymeleaf.context.Context;
 import org.thymeleaf.spring5.SpringTemplateEngine;
@@ -21,6 +22,7 @@ public class MailSenderUtil {
 	private final JavaMailSender mailSender;
 	private final SpringTemplateEngine templateEngine;
 
+	@Async(value = "mailExecutor")
 	public void sendEmail(
 		String subject,
 		String to,

--- a/src/main/java/com/gnimty/communityapiserver/domain/riotaccount/controller/RiotAccountController.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/riotaccount/controller/RiotAccountController.java
@@ -3,7 +3,7 @@ package com.gnimty.communityapiserver.domain.riotaccount.controller;
 import static com.gnimty.communityapiserver.global.constant.ResponseMessage.SUCCESS_UPDATE_SUMMONERS;
 import static org.springframework.http.HttpStatus.OK;
 
-import com.gnimty.communityapiserver.domain.chat.service.ChatService;
+import com.gnimty.communityapiserver.domain.chat.service.StompService;
 import com.gnimty.communityapiserver.domain.member.controller.dto.request.SummonerUpdateRequest;
 import com.gnimty.communityapiserver.domain.member.entity.Member;
 import com.gnimty.communityapiserver.domain.riotaccount.controller.dto.request.RecommendedSummonersRequest;
@@ -32,7 +32,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class RiotAccountController {
 
 	private final RiotAccountService riotAccountService;
-	private final ChatService chatService;
+	private final StompService stompService;
 
 	@PatchMapping
 	public CommonResponse<Void> updateSummoners(
@@ -63,9 +63,9 @@ public class RiotAccountController {
 	@GetMapping("/recently")
 	public CommonResponse<RecentlySummonersResponse> getRecentlySummoners() {
 		Member member = MemberThreadLocal.get();
-		List<Long> chattedMemberIds = chatService.getChattedMemberIds(member.getId());
+		List<Long> chattedMemberIds = stompService.getChattedMemberIds(member.getId());
 		RecentlySummonersServiceResponse response = riotAccountService
-				.getRecentlySummoners(member, chattedMemberIds);
+			.getRecentlySummoners(member, chattedMemberIds);
 		return CommonResponse.success(RecentlySummonersResponse.from(response));
 	}
 }

--- a/src/main/java/com/gnimty/communityapiserver/global/config/WebConfiguration.java
+++ b/src/main/java/com/gnimty/communityapiserver/global/config/WebConfiguration.java
@@ -49,6 +49,6 @@ public class WebConfiguration implements WebMvcConfigurer {
 			.addPathPatterns("/members/**")
 			.excludePathPatterns(
 				"/css/**", "/*.ico"
-				, "/error", "/error-page/**", "/members/me");
+				, "/error", "/error-page/**", "/members/me", "/members/password/**");
 	}
 }

--- a/src/main/java/com/gnimty/communityapiserver/global/exception/ErrorCode.java
+++ b/src/main/java/com/gnimty/communityapiserver/global/exception/ErrorCode.java
@@ -62,6 +62,7 @@ public enum ErrorCode {
 		ErrorMessage.COMMENTS_ID_AND_CHAMPION_ID_INVALID),
 	ALREADY_CHAMPION_COMMENTS_LIKE(CONFLICT, ErrorMessage.ALREADY_CHAMPION_COMMENTS_LIKE),
 	CHAMPION_COMMENTS_LIKE_NOT_FOUND(NOT_FOUND, ErrorMessage.CHAMPION_COMMENTS_LIKE_NOT_FOUND),
+	INVALID_PASSWORD(BAD_REQUEST, ErrorMessage.INVALID_PASSWORD),
 
 	// server
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Server Error");
@@ -122,5 +123,6 @@ public enum ErrorCode {
 		public static final String ALREADY_CHAMPION_COMMENTS_LIKE = "이미 좋아요 또는 싫어요를 한 댓글입니다.";
 		public static final String CHAMPION_COMMENTS_LIKE_NOT_FOUND = "좋아요 또는 싫어요를 하지 않은 댓글입니다.";
 		public static final String NOT_FOUND_CHAT_ROOM = "%d번 채팅방 정보가 존재하지 않습니다.";
+		public static final String INVALID_PASSWORD = "현재 비밀번호가 일치하지 않습니다.";
 	}
 }

--- a/src/main/java/com/gnimty/communityapiserver/global/exception/ErrorCode.java
+++ b/src/main/java/com/gnimty/communityapiserver/global/exception/ErrorCode.java
@@ -63,6 +63,7 @@ public enum ErrorCode {
 	ALREADY_CHAMPION_COMMENTS_LIKE(CONFLICT, ErrorMessage.ALREADY_CHAMPION_COMMENTS_LIKE),
 	CHAMPION_COMMENTS_LIKE_NOT_FOUND(NOT_FOUND, ErrorMessage.CHAMPION_COMMENTS_LIKE_NOT_FOUND),
 	INVALID_PASSWORD(BAD_REQUEST, ErrorMessage.INVALID_PASSWORD),
+	INVALID_UUID(BAD_REQUEST, ErrorMessage.INVALID_UUID),
 
 	// server
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Server Error");
@@ -124,5 +125,6 @@ public enum ErrorCode {
 		public static final String CHAMPION_COMMENTS_LIKE_NOT_FOUND = "좋아요 또는 싫어요를 하지 않은 댓글입니다.";
 		public static final String NOT_FOUND_CHAT_ROOM = "%d번 채팅방 정보가 존재하지 않습니다.";
 		public static final String INVALID_PASSWORD = "현재 비밀번호가 일치하지 않습니다.";
+		public static final String INVALID_UUID = "올바르지 않은 uuid입니다.";
 	}
 }

--- a/src/test/java/com/gnimty/communityapiserver/controller/ControllerTestSupport.java
+++ b/src/test/java/com/gnimty/communityapiserver/controller/ControllerTestSupport.java
@@ -3,7 +3,8 @@ package com.gnimty.communityapiserver.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.gnimty.communityapiserver.domain.block.service.BlockReadService;
 import com.gnimty.communityapiserver.domain.block.service.BlockService;
-import com.gnimty.communityapiserver.domain.chat.service.ChatService;
+import com.gnimty.communityapiserver.domain.chat.service.StompService;
+import com.gnimty.communityapiserver.domain.chat.service.UserService;
 import com.gnimty.communityapiserver.domain.introduction.service.IntroductionReadService;
 import com.gnimty.communityapiserver.domain.member.controller.MemberController;
 import com.gnimty.communityapiserver.domain.member.service.AuthService;
@@ -82,5 +83,8 @@ public abstract class ControllerTestSupport {
 	protected MemberAuthInterceptor memberAuthInterceptor;
 
 	@MockBean
-	protected ChatService chatService;
+	protected StompService stompService;
+
+	@MockBean
+	protected UserService userService;
 }

--- a/src/test/java/com/gnimty/communityapiserver/controller/member/MemberControllerTest.java
+++ b/src/test/java/com/gnimty/communityapiserver/controller/member/MemberControllerTest.java
@@ -11,7 +11,6 @@ import static com.gnimty.communityapiserver.global.constant.ResponseMessage.SUCC
 import static com.gnimty.communityapiserver.global.constant.ResponseMessage.SUCCESS_UPDATE_PREFER_GAME_MODE;
 import static com.gnimty.communityapiserver.global.constant.ResponseMessage.SUCCESS_UPDATE_PROFILE;
 import static com.gnimty.communityapiserver.global.constant.ResponseMessage.SUCCESS_UPDATE_STATUS;
-import static com.gnimty.communityapiserver.global.constant.ResponseMessage.SUCCESS_VERIFY_EMAIL;
 import static com.gnimty.communityapiserver.global.constant.ResponseMessage.SUCCESS_WITHDRAWAL;
 import static com.gnimty.communityapiserver.global.exception.ErrorCode.ErrorMessage.INVALID_INPUT_VALUE;
 import static com.gnimty.communityapiserver.global.exception.ErrorCode.ErrorMessage.MISSING_REQUEST_PARAMETER;
@@ -31,20 +30,25 @@ import com.gnimty.communityapiserver.domain.member.controller.dto.request.Introd
 import com.gnimty.communityapiserver.domain.member.controller.dto.request.MyProfileUpdateRequest;
 import com.gnimty.communityapiserver.domain.member.controller.dto.request.OauthLoginRequest;
 import com.gnimty.communityapiserver.domain.member.controller.dto.request.PasswordEmailVerifyRequest;
+import com.gnimty.communityapiserver.domain.member.controller.dto.request.PasswordResetRequest;
 import com.gnimty.communityapiserver.domain.member.controller.dto.request.PasswordUpdateRequest;
 import com.gnimty.communityapiserver.domain.member.controller.dto.request.PreferGameModeUpdateRequest;
+import com.gnimty.communityapiserver.domain.member.controller.dto.request.SendEmailRequest;
 import com.gnimty.communityapiserver.domain.member.controller.dto.request.StatusUpdateRequest;
 import com.gnimty.communityapiserver.domain.member.service.dto.request.IntroductionUpdateServiceRequest;
 import com.gnimty.communityapiserver.domain.member.service.dto.request.MyProfileUpdateServiceRequest;
 import com.gnimty.communityapiserver.domain.member.service.dto.request.OauthLoginServiceRequest;
 import com.gnimty.communityapiserver.domain.member.service.dto.request.PasswordEmailVerifyServiceRequest;
+import com.gnimty.communityapiserver.domain.member.service.dto.request.PasswordResetServiceRequest;
 import com.gnimty.communityapiserver.domain.member.service.dto.request.PasswordUpdateServiceRequest;
 import com.gnimty.communityapiserver.domain.member.service.dto.request.PreferGameModeUpdateServiceRequest;
+import com.gnimty.communityapiserver.domain.member.service.dto.request.SendEmailServiceRequest;
 import com.gnimty.communityapiserver.domain.member.service.dto.request.StatusUpdateServiceRequest;
 import com.gnimty.communityapiserver.domain.member.service.dto.response.IntroductionEntry;
 import com.gnimty.communityapiserver.domain.member.service.dto.response.MyProfileServiceResponse;
 import com.gnimty.communityapiserver.domain.member.service.dto.response.OauthInfoEntry;
 import com.gnimty.communityapiserver.domain.member.service.dto.response.OtherProfileServiceResponse;
+import com.gnimty.communityapiserver.domain.member.service.dto.response.PasswordEmailVerifyServiceResponse;
 import com.gnimty.communityapiserver.domain.member.service.dto.response.PreferGameModeEntry;
 import com.gnimty.communityapiserver.domain.member.service.dto.response.RiotAccountEntry;
 import com.gnimty.communityapiserver.domain.member.service.dto.response.RiotDependentInfo;
@@ -56,6 +60,7 @@ import com.gnimty.communityapiserver.global.constant.Provider;
 import com.gnimty.communityapiserver.global.constant.Status;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.UUID;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.BeforeEach;
@@ -101,7 +106,7 @@ public class MemberControllerTest extends ControllerTestSupport {
 			given(memberService.summonerAccountLink(any(OauthLoginServiceRequest.class)))
 				.willReturn(null);
 			willDoNothing()
-				.given(chatService)
+				.given(stompService)
 				.createOrUpdateUser(any(RiotAccount.class));
 
 			mockMvc.perform(post(REQUEST_URL, MEMBER_ID)
@@ -125,7 +130,7 @@ public class MemberControllerTest extends ControllerTestSupport {
 			given(memberService.summonerAccountLink(any(OauthLoginServiceRequest.class)))
 				.willReturn(null);
 			willDoNothing()
-				.given(chatService)
+				.given(stompService)
 				.createOrUpdateUser(any(RiotAccount.class));
 
 			mockMvc.perform(post(REQUEST_URL, MEMBER_ID)
@@ -312,10 +317,10 @@ public class MemberControllerTest extends ControllerTestSupport {
 				any(MyProfileUpdateServiceRequest.class)))
 				.willReturn(null);
 			willDoNothing()
-				.given(chatService)
+				.given(stompService)
 				.updateConnStatus(any(User.class), any(Status.class));
 			willDoNothing()
-				.given(chatService)
+				.given(stompService)
 				.createOrUpdateUser(any(RiotAccount.class));
 
 			mockMvc.perform(patch(REQUEST_URL, MEMBER_ID)
@@ -337,10 +342,10 @@ public class MemberControllerTest extends ControllerTestSupport {
 				any(MyProfileUpdateServiceRequest.class)))
 				.willReturn(null);
 			willDoNothing()
-				.given(chatService)
+				.given(stompService)
 				.updateConnStatus(any(User.class), any(Status.class));
 			willDoNothing()
-				.given(chatService)
+				.given(stompService)
 				.createOrUpdateUser(any(RiotAccount.class));
 
 			mockMvc.perform(patch(REQUEST_URL, MEMBER_ID)
@@ -362,10 +367,10 @@ public class MemberControllerTest extends ControllerTestSupport {
 				any(MyProfileUpdateServiceRequest.class)))
 				.willReturn(null);
 			willDoNothing()
-				.given(chatService)
+				.given(stompService)
 				.updateConnStatus(any(User.class), any(Status.class));
 			willDoNothing()
-				.given(chatService)
+				.given(stompService)
 				.createOrUpdateUser(any(RiotAccount.class));
 
 			mockMvc.perform(patch(REQUEST_URL, MEMBER_ID)
@@ -395,18 +400,24 @@ public class MemberControllerTest extends ControllerTestSupport {
 	@Nested
 	class SendEmailAuthCode {
 
-		private static final String REQUEST_URL = "/members/{member_id}/password/email";
-		private static final Long MEMBER_ID = 1L;
+		private static final String REQUEST_URL = "/members/password/email";
 
-		@DisplayName("로그인 한 유저의 경우 이메일이 전송된다.")
+		@DisplayName("form 로그인 회원의 경우 이메일이 전송된다.")
 		@Test
 		void should_sendEmail_when_invokeMethod() throws Exception {
 
+			SendEmailRequest request = SendEmailRequest.builder()
+				.email("email@email.com")
+				.build();
+
 			willDoNothing()
 				.given(memberService)
-				.sendEmailAuthCode();
+				.sendEmailAuthCode(any(SendEmailServiceRequest.class));
 
-			mockMvc.perform(post(REQUEST_URL, MEMBER_ID))
+			mockMvc.perform(post(REQUEST_URL)
+					.content(om.writeValueAsString(request))
+					.contentType(MediaType.APPLICATION_JSON)
+					.characterEncoding(StandardCharsets.UTF_8))
 				.andExpectAll(
 					status().isAccepted(),
 					jsonPath("$.status.message").value(
@@ -419,26 +430,27 @@ public class MemberControllerTest extends ControllerTestSupport {
 	@Nested
 	class VerifyEmailAuthCode {
 
-		private static final String REQUEST_URL = "/members/{member_id}/password/email/code";
-		private static final Long MEMBER_ID = 1L;
+		private static final String REQUEST_URL = "/members/password/email/code";
 
 		@DisplayName("올바른 코드를 요청하면 성공한다.")
 		@Test
 		void should_success_when_validCode() throws Exception {
 
 			PasswordEmailVerifyRequest request = createRequest("ABC123");
+			PasswordEmailVerifyServiceResponse response = PasswordEmailVerifyServiceResponse.builder()
+				.uuid(UUID.randomUUID().toString())
+				.build();
 
-			willDoNothing()
-				.given(memberService)
-				.verifyEmailAuthCode(any(PasswordEmailVerifyServiceRequest.class));
+			given(memberService.verifyEmailAuthCode(any(PasswordEmailVerifyServiceRequest.class)))
+				.willReturn(response);
 
-			mockMvc.perform(post(REQUEST_URL, MEMBER_ID)
+			mockMvc.perform(post(REQUEST_URL)
 					.content(om.writeValueAsString(request))
 					.contentType(MediaType.APPLICATION_JSON)
 					.characterEncoding(StandardCharsets.UTF_8))
 				.andExpectAll(
 					status().isOk(),
-					jsonPath("$.status.message").value(SUCCESS_VERIFY_EMAIL.getMessage())
+					jsonPath("$.data.uuid").value(response.getUuid())
 				);
 		}
 
@@ -449,12 +461,14 @@ public class MemberControllerTest extends ControllerTestSupport {
 		void should_fail_when_inValidCode(String code) throws Exception {
 
 			PasswordEmailVerifyRequest request = createRequest(code);
+			PasswordEmailVerifyServiceResponse response = PasswordEmailVerifyServiceResponse.builder()
+				.uuid(UUID.randomUUID().toString())
+				.build();
 
-			willDoNothing()
-				.given(memberService)
-				.verifyEmailAuthCode(any(PasswordEmailVerifyServiceRequest.class));
+			given(memberService.verifyEmailAuthCode(any(PasswordEmailVerifyServiceRequest.class)))
+				.willReturn(response);
 
-			mockMvc.perform(post(REQUEST_URL, MEMBER_ID)
+			mockMvc.perform(post(REQUEST_URL)
 					.content(om.writeValueAsString(request))
 					.contentType(MediaType.APPLICATION_JSON)
 					.characterEncoding(StandardCharsets.UTF_8))
@@ -466,7 +480,63 @@ public class MemberControllerTest extends ControllerTestSupport {
 
 		private PasswordEmailVerifyRequest createRequest(String code) {
 			return PasswordEmailVerifyRequest.builder()
+				.email("email@email.com")
 				.code(code)
+				.build();
+		}
+	}
+
+	@DisplayName("비밀번호 재설정 시")
+	@Nested
+	class ResetPassword {
+
+		private static final String REQUEST_URL = "/members/password";
+
+		@DisplayName("올바른 요청이면 성공한다.")
+		@Test
+		void should_success_when_validRequest() throws Exception {
+			PasswordResetRequest request = createRequest(UUID.randomUUID().toString(), "Abc123**");
+
+			willDoNothing()
+				.given(memberService)
+				.resetPassword(any(PasswordResetServiceRequest.class));
+
+			mockMvc.perform(patch(REQUEST_URL)
+					.content(om.writeValueAsString(request))
+					.contentType(MediaType.APPLICATION_JSON)
+					.characterEncoding(StandardCharsets.UTF_8))
+				.andExpectAll(
+					status().isOk(),
+					jsonPath("$.status.message").value(SUCCESS_UPDATE_PASSWORD.getMessage())
+				);
+		}
+
+		@DisplayName("비밀번호가 null이거나 정규 표현식에 위배되면 실패한다.")
+		@NullAndEmptySource
+		@ParameterizedTest
+		@ValueSource(strings = {"abc123**", "ABC123*", "ABC123***********", "ABC12345", "ABCD****"})
+		void should_fail_when_invalidPassword(String password) throws Exception {
+			PasswordResetRequest request = createRequest(UUID.randomUUID().toString(), password);
+
+			willDoNothing()
+				.given(memberService)
+				.updatePassword(any(Long.class), any(PasswordUpdateServiceRequest.class));
+
+			mockMvc.perform(patch(REQUEST_URL)
+					.content(om.writeValueAsString(request))
+					.contentType(MediaType.APPLICATION_JSON)
+					.characterEncoding(StandardCharsets.UTF_8))
+				.andExpectAll(
+					status().isBadRequest(),
+					jsonPath("$.status.message").value(INVALID_INPUT_VALUE)
+				);
+		}
+
+		private PasswordResetRequest createRequest(String uuid, String password) {
+			return PasswordResetRequest.builder()
+				.email("email@email.com")
+				.uuid(uuid)
+				.password(password)
 				.build();
 		}
 	}
@@ -520,7 +590,8 @@ public class MemberControllerTest extends ControllerTestSupport {
 
 		private PasswordUpdateRequest createRequest(String password) {
 			return PasswordUpdateRequest.builder()
-				.password(password)
+				.currentPassword("aBC123**")
+				.newPassword(password)
 				.build();
 		}
 	}
@@ -542,7 +613,7 @@ public class MemberControllerTest extends ControllerTestSupport {
 				.given(memberService)
 				.updateStatus(any(Long.class), any(StatusUpdateServiceRequest.class));
 			willDoNothing()
-				.given(chatService)
+				.given(stompService)
 				.updateConnStatus(any(User.class), any(Status.class));
 
 			mockMvc.perform(patch(REQUEST_URL, MEMBER_ID)
@@ -565,7 +636,7 @@ public class MemberControllerTest extends ControllerTestSupport {
 				.given(memberService)
 				.updateStatus(any(Long.class), any(StatusUpdateServiceRequest.class));
 			willDoNothing()
-				.given(chatService)
+				.given(stompService)
 				.updateConnStatus(any(User.class), any(Status.class));
 
 			mockMvc.perform(patch(REQUEST_URL, MEMBER_ID)

--- a/src/test/java/com/gnimty/communityapiserver/controller/member/MemberControllerTest.java
+++ b/src/test/java/com/gnimty/communityapiserver/controller/member/MemberControllerTest.java
@@ -69,6 +69,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.http.MediaType;
 
@@ -424,6 +425,26 @@ public class MemberControllerTest extends ControllerTestSupport {
 						SUCCESS_SEND_EMAIL_AUTH_CODE.getMessage())
 				);
 		}
+
+		@DisplayName("이메일 형태가 올바르지 않을 경우 실패한다.")
+		@ParameterizedTest
+		@NullAndEmptySource
+		@ValueSource(strings = {"abc123", "abc@@asdf", "abc123@naver", "abc123@.com"})
+		void should_fail_when_invalidEmail(String email) throws Exception {
+
+			SendEmailRequest request = SendEmailRequest.builder()
+				.email(email)
+				.build();
+
+			mockMvc.perform(post(REQUEST_URL)
+					.content(om.writeValueAsString(request))
+					.contentType(MediaType.APPLICATION_JSON)
+					.characterEncoding(StandardCharsets.UTF_8))
+				.andExpectAll(
+					status().isBadRequest(),
+					jsonPath("$.status.message").value(INVALID_INPUT_VALUE)
+				);
+		}
 	}
 
 	@DisplayName("비밀번호 변경 인증 코드 전송 시")
@@ -478,6 +499,26 @@ public class MemberControllerTest extends ControllerTestSupport {
 				);
 		}
 
+		@DisplayName("이메일 형태가 올바르지 않을 경우 실패한다.")
+		@ParameterizedTest
+		@NullAndEmptySource
+		@ValueSource(strings = {"abc123", "abc@@asdf", "abc123@naver", "abc123@.com"})
+		void should_fail_when_invalidEmail(String email) throws Exception {
+
+			PasswordEmailVerifyRequest request = PasswordEmailVerifyRequest.builder()
+				.email(email)
+				.build();
+
+			mockMvc.perform(post(REQUEST_URL)
+					.content(om.writeValueAsString(request))
+					.contentType(MediaType.APPLICATION_JSON)
+					.characterEncoding(StandardCharsets.UTF_8))
+				.andExpectAll(
+					status().isBadRequest(),
+					jsonPath("$.status.message").value(INVALID_INPUT_VALUE)
+				);
+		}
+
 		private PasswordEmailVerifyRequest createRequest(String code) {
 			return PasswordEmailVerifyRequest.builder()
 				.email("email@email.com")
@@ -521,6 +562,45 @@ public class MemberControllerTest extends ControllerTestSupport {
 			willDoNothing()
 				.given(memberService)
 				.updatePassword(any(Long.class), any(PasswordUpdateServiceRequest.class));
+
+			mockMvc.perform(patch(REQUEST_URL)
+					.content(om.writeValueAsString(request))
+					.contentType(MediaType.APPLICATION_JSON)
+					.characterEncoding(StandardCharsets.UTF_8))
+				.andExpectAll(
+					status().isBadRequest(),
+					jsonPath("$.status.message").value(INVALID_INPUT_VALUE)
+				);
+		}
+
+		@DisplayName("이메일 형태가 올바르지 않을 경우 실패한다.")
+		@ParameterizedTest
+		@NullAndEmptySource
+		@ValueSource(strings = {"abc123", "abc@@asdf", "abc123@naver", "abc123@.com"})
+		void should_fail_when_invalidEmail(String email) throws Exception {
+
+			PasswordResetRequest request = PasswordResetRequest.builder()
+				.email(email)
+				.build();
+
+			mockMvc.perform(patch(REQUEST_URL)
+					.content(om.writeValueAsString(request))
+					.contentType(MediaType.APPLICATION_JSON)
+					.characterEncoding(StandardCharsets.UTF_8))
+				.andExpectAll(
+					status().isBadRequest(),
+					jsonPath("$.status.message").value(INVALID_INPUT_VALUE)
+				);
+		}
+
+		@DisplayName("uuid가 null일 경우 실패한다.")
+		@ParameterizedTest
+		@NullSource
+		void should_fail_when_invalidUUID(String uuid) throws Exception {
+
+			PasswordResetRequest request = PasswordResetRequest.builder()
+				.uuid(uuid)
+				.build();
 
 			mockMvc.perform(patch(REQUEST_URL)
 					.content(om.writeValueAsString(request))


### PR DESCRIPTION
this closes #52 

- 비밀번호 수정 시
  - 이메일 인증 x
  - {현재 비밀번호, 변경할 비밀번호}만 입력 받은 후 변경


- 비밀번호 찾기 시
  - 이메일 발송/인증 -> 인증되지 않은 상태(member_id, token 필요없음)
  - 인증시에 UUID 만료 시간 걸어서 응답
  - 이후 새로운 비밀번호 설정