### PR TITLE
Feat: 사용자 탈퇴 시 관련 채팅 데이터 삭제

### DIFF
--- a/src/main/java/com/gnimty/communityapiserver/domain/chat/service/StompService.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/chat/service/StompService.java
@@ -119,6 +119,20 @@ public class StompService {
 		}
     }
 
+
+	public void destroyWithdrawnUserData(Long actualUserId) {
+		User user = userService.getUser(actualUserId);
+		userService.delete(user);
+
+		chatRoomService.findChatRoom(user)
+			.forEach(chatRoom -> {
+				chatRoomService.delete(chatRoom.getChatRoomNo());
+				chatService.delete(chatRoom.getChatRoomNo());
+				sendToChatRoomSubscribers(chatRoom.getChatRoomNo(), new MessageResponse(MessageResponseType.DELETED_CHATROOM, chatRoom.getId()));
+			});
+	}
+
+
 	public void createOrUpdateUser(List<RiotAccount> accounts){
 		List<User> users = accounts.stream().map(account-> User.toUser(account)).toList();
 
@@ -226,6 +240,7 @@ public class StompService {
 				chatService.save(chat);
 			});
 	}
+
 
 	public void sendToUserSubscribers(String userId, MessageResponse response){
 		template.convertAndSend("/sub/user/" + userId, response);

--- a/src/main/java/com/gnimty/communityapiserver/domain/chat/service/UserService.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/chat/service/UserService.java
@@ -49,4 +49,8 @@ public class UserService {
     public BulkWriteResult updateMany(List<User> users) {
         return userRepository.bulkUpdate(users);
     }
+
+    public void delete(User user) {
+        userRepository.delete(user);
+    }
 }

--- a/src/main/java/com/gnimty/communityapiserver/global/constant/MessageResponseType.java
+++ b/src/main/java/com/gnimty/communityapiserver/global/constant/MessageResponseType.java
@@ -6,5 +6,7 @@ public enum MessageResponseType {
     CHATROOM_INFO,
     CHAT_MESSAGE,
 
+    DELETED_CHATROOM,
+
     READ_CHATS
 }


### PR DESCRIPTION
사용자 탈퇴 시
- 사용자를 포함한 채팅방과 해당 채팅방의 채팅내역 모두 삭제
- 해당 채팅방에 있는 사용자에게 MESSAGE(response 타입: DELETED_CHATROOM)