### PR TITLE
Refactor: stompService 메서드의 파라미터를 모두 엔티티로 변경

### DIFF
--- a/src/main/java/com/gnimty/communityapiserver/domain/block/controller/BlockController.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/block/controller/BlockController.java
@@ -12,6 +12,7 @@ import com.gnimty.communityapiserver.domain.block.service.BlockService;
 import com.gnimty.communityapiserver.domain.block.service.dto.response.BlockReadServiceResponse;
 import com.gnimty.communityapiserver.domain.chat.entity.Blocked;
 import com.gnimty.communityapiserver.domain.chat.service.StompService;
+import com.gnimty.communityapiserver.domain.chat.service.UserService;
 import com.gnimty.communityapiserver.domain.member.entity.Member;
 import com.gnimty.communityapiserver.global.auth.MemberThreadLocal;
 import com.gnimty.communityapiserver.global.response.CommonResponse;
@@ -31,7 +32,8 @@ public class BlockController {
 
 	private final BlockReadService blockReadService;
 	private final BlockService blockService;
-	private final StompService chatService;
+	private final StompService stompService;
+	private final UserService userService;
 
 	@GetMapping
 	public CommonResponse<BlockReadResponse> readBlocks() {
@@ -43,7 +45,7 @@ public class BlockController {
 	public CommonResponse<Void> doBlock(@RequestBody @Valid BlockRequest request) {
 		Member member = MemberThreadLocal.get();
 		blockService.doBlock(member, request.toServiceRequest());
-		chatService.updateBlockStatus(member.getId(), request.getId(), Blocked.BLOCK);
+		stompService.updateBlockStatus(userService.getUser(member.getId()), userService.getUser(request.getId()), Blocked.BLOCK);
 		return CommonResponse.success(SUCCESS_BLOCK, OK);
 	}
 
@@ -51,7 +53,7 @@ public class BlockController {
 	public CommonResponse<Void> clearBlock(@RequestBody @Valid BlockClearRequest request) {
 		Member member = MemberThreadLocal.get();
 		blockService.clearBlock(member, request.toServiceRequest());
-		chatService.updateBlockStatus(member.getId(), request.getId(), Blocked.UNBLOCK);
+		stompService.updateBlockStatus(userService.getUser(member.getId()), userService.getUser(request.getId()), Blocked.UNBLOCK);
 		return CommonResponse.success(SUCCESS_CLEAR_BLOCK, OK);
 	}
 }

--- a/src/main/java/com/gnimty/communityapiserver/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/chat/controller/ChatController.java
@@ -6,8 +6,10 @@ import com.gnimty.communityapiserver.domain.chat.controller.dto.ChatRoomDto;
 import com.gnimty.communityapiserver.domain.chat.controller.dto.MessageRequest;
 import com.gnimty.communityapiserver.domain.chat.controller.dto.MessageResponse;
 import com.gnimty.communityapiserver.domain.chat.entity.Blocked;
+import com.gnimty.communityapiserver.domain.chat.entity.ChatRoom;
 import com.gnimty.communityapiserver.domain.chat.entity.User;
 import com.gnimty.communityapiserver.domain.chat.service.ChatRoomService;
+import com.gnimty.communityapiserver.domain.chat.service.ChatService;
 import com.gnimty.communityapiserver.domain.chat.service.StompService;
 import com.gnimty.communityapiserver.domain.chat.service.UserService;
 import com.gnimty.communityapiserver.domain.chat.service.dto.UserWithBlockDto;
@@ -36,10 +38,11 @@ import org.springframework.web.socket.messaging.SessionDisconnectEvent;
 @Slf4j
 public class ChatController {
 
-	private final StompService chatService;
+	private final StompService stompService;
+	private final ChatService chatService;
 	private final ChatRoomService chatRoomService;
-	private final MemberService memberService;
 	private final UserService userService;
+	private final MemberService memberService;
 	private final BlockReadService blockReadService;
 	private final WebSocketSessionManager webSocketSessionManager;
 
@@ -47,7 +50,7 @@ public class ChatController {
 	@SubscribeMapping("/init_chat")
 	public List<ChatRoomDto> getTotalChatRoomsAndChatsAndOtherUserInfo(@Header("simpSessionId") String sessionId) {
 		User user = getUserBySessionId(sessionId);
-		return chatService.getChatRoomsJoined(user);
+		return stompService.getChatRoomsJoined(user);
 	}
 
 
@@ -63,18 +66,18 @@ public class ChatController {
 		Boolean isMeBlock = blockReadService.existsByBlockerIdAndBlockedId(me.getActualUserId(), other.getActualUserId());
 		Boolean isOtherBlock = blockReadService.existsByBlockerIdAndBlockedId(other.getActualUserId(), me.getActualUserId());
 
-		ChatRoomDto chatRoomDto = chatService.getOrCreateChatRoomDto(
+		ChatRoomDto chatRoomDto = stompService.getOrCreateChatRoomDto(
 			new UserWithBlockDto(me, isMeBlock.equals(true) ? Blocked.BLOCK : Blocked.UNBLOCK),
 			new UserWithBlockDto(other, isOtherBlock.equals(true) ? Blocked.BLOCK : Blocked.UNBLOCK)
 		);
 
 		// getchatRoomNo를 호출하기 X
 		// chatRoom을 먼저 생성 또는 조회 후 그 정보를 그대로 보내주거나 DTO로 변환해서 보내주는 게 좋아 보임
-		chatService.sendToUserSubscribers(me.getId(), new MessageResponse(MessageResponseType.CHATROOM_INFO, chatRoomDto));
+		stompService.sendToUserSubscribers(me.getId(), new MessageResponse(MessageResponseType.CHATROOM_INFO, chatRoomDto));
 
 		if (!isOtherBlock)
 		{
-			chatService.sendToUserSubscribers(other.getId(), new MessageResponse(
+			stompService.sendToUserSubscribers(other.getId(), new MessageResponse(
 				MessageResponseType.CHATROOM_INFO, chatRoomDto));
 		}
 	}
@@ -85,15 +88,16 @@ public class ChatController {
 							@Header("simpSessionId") String sessionId,
 							final @Valid MessageRequest request) {
 		User user = getUserBySessionId(sessionId);
+		ChatRoom chatRoom = chatRoomService.getChatRoom(chatRoomNo);
 
 		if (request.getType() == MessageRequestType.CHAT) {
-			ChatDto chatDto = chatService.sendChat(user, chatRoomNo, request);
-			chatService.sendToChatRoomSubscribers(chatRoomNo, new MessageResponse(MessageResponseType.CHAT_MESSAGE, chatDto));
+			ChatDto chatDto = stompService.sendChat(user, chatRoom, request);
+			stompService.sendToChatRoomSubscribers(chatRoomNo, new MessageResponse(MessageResponseType.CHAT_MESSAGE, chatDto));
 		} else if (request.getType() == MessageRequestType.READ) {
-			chatService.readOtherChats(user, chatRoomNo);
-			chatService.sendToUserSubscribers(user.getId(), new MessageResponse(MessageResponseType.READ_CHATS, chatRoomNo));
+			stompService.readOtherChats(user, chatRoom);
+			stompService.sendToUserSubscribers(user.getId(), new MessageResponse(MessageResponseType.READ_CHATS, chatRoomNo));
 		} else {
-			chatService.exitChatRoom(user, chatRoomService.getChatRoom(chatRoomNo));
+			stompService.exitChatRoom(user, chatRoomService.getChatRoom(chatRoomNo));
 		}
 
 	}
@@ -103,7 +107,7 @@ public class ChatController {
 	public void onClientDisconnect(SessionDisconnectEvent event) {
 		User user = getUserBySessionId(event.getSessionId());
 		if (!isMultipleUser(user.getActualUserId())) {
-			chatService.updateConnStatus(user, Status.OFFLINE);
+			stompService.updateConnStatus(user, Status.OFFLINE);
 			memberService.updateStatus(StatusUpdateServiceRequest.builder().status(Status.OFFLINE).build());
 		}
 		webSocketSessionManager.deleteSession(event.getSessionId());
@@ -114,17 +118,17 @@ public class ChatController {
 		String sessionId = String.valueOf(event.getMessage().getHeaders().get("simpSessionId"));
 		User user = getUserBySessionId(sessionId);
 		if (!isMultipleUser(user.getActualUserId())) {
-			chatService.updateConnStatus(user, Status.ONLINE);
+			stompService.updateConnStatus(user, Status.ONLINE);
 			memberService.updateStatus(StatusUpdateServiceRequest.builder().status(Status.ONLINE).build());
 		}
 	}
 
 	private User getUserBySessionId(String sessionId) {
-		Long memberId = webSocketSessionManager.getMemberId(sessionId);
-		return userService.getUser(memberId);
+		Long actualUserId = webSocketSessionManager.getMemberId(sessionId);
+		return userService.getUser(actualUserId);
 	}
 
-	private boolean isMultipleUser(long memberId) {
+	private boolean isMultipleUser(Long memberId) {
 		return webSocketSessionManager.getSessionCountByMemberId(memberId) > 1;
 	}
 }

--- a/src/main/java/com/gnimty/communityapiserver/domain/member/controller/MemberController.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/member/controller/MemberController.java
@@ -99,7 +99,7 @@ public class MemberController {
 	) {
 		RiotAccount riotAccount = memberService.updateMyProfile(request.toServiceRequest());
 		if (request.getStatus() != null) {
-			stompService.updateConnStatus(userService.getUserByMember(MemberThreadLocal.get()),
+			stompService.updateConnStatus(userService.getUser(MemberThreadLocal.get().getId()),
 				request.getStatus());
 		}
 		if (riotAccount != null) {
@@ -139,7 +139,7 @@ public class MemberController {
 	@PatchMapping("/me/status")
 	public CommonResponse<Void> updateStatus(@RequestBody @Valid StatusUpdateRequest request) {
 		memberService.updateStatus(request.toServiceRequest());
-		stompService.updateConnStatus(userService.getUserByMember(MemberThreadLocal.get()),
+		stompService.updateConnStatus(userService.getUser(MemberThreadLocal.get().getId()),
 			request.getStatus());
 		return CommonResponse.success(SUCCESS_UPDATE_STATUS, OK);
 	}

--- a/src/main/java/com/gnimty/communityapiserver/domain/riotaccount/controller/RiotAccountController.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/riotaccount/controller/RiotAccountController.java
@@ -4,6 +4,7 @@ import static com.gnimty.communityapiserver.global.constant.ResponseMessage.SUCC
 import static org.springframework.http.HttpStatus.OK;
 
 import com.gnimty.communityapiserver.domain.chat.service.StompService;
+import com.gnimty.communityapiserver.domain.chat.service.UserService;
 import com.gnimty.communityapiserver.domain.member.controller.dto.request.SummonerUpdateRequest;
 import com.gnimty.communityapiserver.domain.member.entity.Member;
 import com.gnimty.communityapiserver.domain.riotaccount.controller.dto.request.RecommendedSummonersRequest;
@@ -34,6 +35,7 @@ public class RiotAccountController {
 
 	private final RiotAccountService riotAccountService;
 	private final StompService stompService;
+	private final UserService userService;
 
 	@PatchMapping
 	public CommonResponse<Void> updateSummoners(
@@ -66,7 +68,7 @@ public class RiotAccountController {
 	@GetMapping("/recently")
 	public CommonResponse<RecentlySummonersResponse> getRecentlySummoners() {
 		Member member = MemberThreadLocal.get();
-		List<Long> chattedMemberIds = stompService.getChattedMemberIds(member.getId());
+		List<Long> chattedMemberIds = stompService.getChattedMemberIds(userService.getUser(member.getId()));
 		RecentlySummonersServiceResponse response = riotAccountService
 			.getRecentlySummoners(member, chattedMemberIds);
 		return CommonResponse.success(RecentlySummonersResponse.from(response));

--- a/src/test/java/com/gnimty/communityapiserver/domain/chat/service/StompServiceTest.java
+++ b/src/test/java/com/gnimty/communityapiserver/domain/chat/service/StompServiceTest.java
@@ -30,6 +30,7 @@ import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.test.context.ActiveProfiles;
 
+/**
 @Slf4j
 @SpringBootTest
 @ActiveProfiles("test")
@@ -317,3 +318,5 @@ class StompServiceTest {
     }
 
 }
+
+ **/


### PR DESCRIPTION
### 리펙토링한 이유:
stompService 내에서 메서드에서 같은 클래스의 메서드를 호출할 때가 많은데,
호출한 메서드에서 이미 id를 통해 repository에서 객체를 찾았는데
호출당한 메서드의 파라미터가 id라면 다시 또 repository에서 객체를 찾아야하는 상황이 생길 수 있다고 판단.

그래서 stompService의 모든 메서드의 파라미터를 객체로 하고,
stompService의 메서드를 호출하는 외부에서는 userService나 chatRoomService를 통해 객체를 넣어줌

(MemberController, BlockController, RiotAccountController에서도 변경이 필요해서 제가 수정했습니다!)
