### PR TITLE
Fix/#98: user 필드 수정 (자유랭크 포함)

### DIFF
--- a/src/main/java/com/gnimty/communityapiserver/domain/chat/entity/User.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/chat/entity/User.java
@@ -6,23 +6,21 @@ import com.gnimty.communityapiserver.global.constant.Lane;
 import com.gnimty.communityapiserver.global.constant.Status;
 import com.gnimty.communityapiserver.global.constant.Tier;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import javax.persistence.Id;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import lombok.ToString;
 import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 @Document(collection = "user")
 @Getter
-@Setter
 @AllArgsConstructor
 @NoArgsConstructor
 @ToString
@@ -34,72 +32,99 @@ public class User {
 	private String id;
 	@Indexed(unique = true)
 	private Long actualUserId;
+
+	private String name;
+	private String internalName;
+	private String tagLine;
+	private String internalTagName;
+	private Status status;
 	private Long profileIconId;
+	private String puuid;
+
+	// 솔로 랭크
 	private Tier tier;
 	private Integer division;
 	private Long lp;
-	private String name;
-	private String tagLine;
-	private Status status;
+	private Long mmr;
 	private List<Lane> mostLanes;
 	private List<Long> mostChampions;
+
+	// 자유 랭크
+	private Tier tierFlex;
+	private Integer divisionFlex;
+	private Long lpFlex;
+	private Long mmrFlex;
+	private List<Lane> mostLanesFlex;
+	private List<Long> mostChampionsFlex;
+
 
 	public static User toUser(RiotAccount riotAccount) {
 		return User.builder()
 			.actualUserId(riotAccount.getMember().getId())
+			.name(riotAccount.getName())
+			.internalName(riotAccount.getInternalName())
+			.tagLine(riotAccount.getTagLine())
+			.internalTagName(riotAccount.getInternalTagName())
 			.profileIconId(riotAccount.getIconId())
+			.puuid(riotAccount.getPuuid())
+			// 솔로 랭크
 			.tier(riotAccount.getQueue())
 			.division(riotAccount.getDivision())
-			.name(riotAccount.getName())
-			.tagLine(riotAccount.getTagLine())
-			.mostLanes(getMostLanes(riotAccount))
-			.mostChampions(getMostChampions(riotAccount))
 			.lp(riotAccount.getLp())
+			.mmr(riotAccount.getMmr())
+			.mostLanes(toListMostItems(riotAccount.getFrequentLane1(), riotAccount.getFrequentLane2()))
+			.mostChampions(
+				toListMostItems(riotAccount.getFrequentChampionId1(), riotAccount.getFrequentChampionId2(),
+					riotAccount.getFrequentChampionId3()))
+			// 자유 랭크
+			.tierFlex(riotAccount.getQueueFlex())
+			.divisionFlex(riotAccount.getDivisionFlex())
+			.lpFlex(riotAccount.getLpFlex())
+			.mmrFlex(riotAccount.getMmrFlex())
+			.mostLanesFlex(toListMostItems(riotAccount.getFrequentLane1Flex(), riotAccount.getFrequentLane2Flex()))
+			.mostChampionsFlex(
+				toListMostItems(riotAccount.getFrequentChampionId1Flex(), riotAccount.getFrequentChampionId2Flex(),
+					riotAccount.getFrequentChampionId3Flex()))
 			.build();
 	}
 
 	public void updateByRiotAccount(RiotAccount riotAccount) {
 		this.actualUserId = riotAccount.getMember().getId();
-		this.profileIconId = riotAccount.getIconId();
-		this.tier = riotAccount.getQueue();
 		this.name = riotAccount.getName();
+		this.internalName = riotAccount.getInternalName();
 		this.tagLine = riotAccount.getTagLine();
-		this.lp = riotAccount.getLp();
+		this.internalTagName = riotAccount.getInternalTagName();
+		this.profileIconId = riotAccount.getIconId();
+		this.puuid = riotAccount.getPuuid();
+		// 솔로 랭크
+		this.tier = riotAccount.getQueue();
 		this.division = riotAccount.getDivision();
-		this.mostChampions = getMostChampions();
-		this.mostLanes = getMostLanes();
-	}
+		this.lp = riotAccount.getLp();
+		this.mmr = riotAccount.getMmr();
+		this.mostLanes = toListMostItems(riotAccount.getFrequentLane1(), riotAccount.getFrequentLane2());
+		this.mostChampions = toListMostItems(riotAccount.getFrequentChampionId1(), riotAccount.getFrequentChampionId2(),
+			riotAccount.getFrequentChampionId3());
+		// 자유 랭크
+		this.tierFlex = riotAccount.getQueueFlex();
+		this.divisionFlex = riotAccount.getDivisionFlex();
+		this.lpFlex = riotAccount.getLpFlex();
+		this.mmrFlex = riotAccount.getMmrFlex();
+		this.mostLanesFlex = toListMostItems(riotAccount.getFrequentLane1Flex(), riotAccount.getFrequentLane2Flex());
+		this.mostChampionsFlex = toListMostItems(riotAccount.getFrequentChampionId1Flex(),
+			riotAccount.getFrequentChampionId2Flex(), riotAccount.getFrequentChampionId3Flex());
 
-	public void updateByUser(User updatedUser) {
-		this.profileIconId = Optional.ofNullable(updatedUser.getProfileIconId())
-			.orElse(this.profileIconId);
-		this.tier = Optional.ofNullable(updatedUser.getTier()).orElse(this.tier);
-		this.name = Optional.ofNullable(updatedUser.getName()).orElse(this.name);
-		this.tagLine = Optional.ofNullable(updatedUser.getTagLine()).orElse(this.tagLine);
-		this.lp = Optional.ofNullable(updatedUser.getLp()).orElse(this.lp);
-		this.division = Optional.ofNullable(updatedUser.getDivision()).orElse(this.division);
-		this.status = Optional.ofNullable(updatedUser.getStatus()).orElse(this.status);
 	}
 
 	public void updateStatus(Status status) {
 		this.status = status;
 	}
 
-	private static List<Long> getMostChampions(RiotAccount riotAccount) {
-		List<Long> mostChampions = new ArrayList<>(List.of(
-			riotAccount.getFrequentChampionId1(),
-			riotAccount.getFrequentChampionId2(),
-			riotAccount.getFrequentChampionId3()));
 
-		mostChampions.removeIf(Objects::isNull);
-		return mostChampions;
+	private static <T> List<T> toListMostItems(T... items) {
+		List<T> mostItems = new ArrayList<>(Arrays.asList(items));
+		mostItems.removeIf(Objects::isNull);
+		return mostItems;
 	}
 
-	private static List<Lane> getMostLanes(RiotAccount riotAccount) {
-		List<Lane> mostLanes = new ArrayList<>(List.of(
-			riotAccount.getFrequentLane1(), riotAccount.getFrequentLane2()));
 
-		mostLanes.removeIf(Objects::isNull);
-		return mostLanes;
-	}
 }

--- a/src/main/java/com/gnimty/communityapiserver/domain/chat/entity/User.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/chat/entity/User.java
@@ -34,7 +34,6 @@ public class User {
 	private Long actualUserId;
 
 	private String name;
-	private String internalName;
 	private String tagLine;
 	private String internalTagName;
 	private Status status;
@@ -62,7 +61,6 @@ public class User {
 		return User.builder()
 			.actualUserId(riotAccount.getMember().getId())
 			.name(riotAccount.getName())
-			.internalName(riotAccount.getInternalName())
 			.tagLine(riotAccount.getTagLine())
 			.internalTagName(riotAccount.getInternalTagName())
 			.profileIconId(riotAccount.getIconId())
@@ -91,7 +89,6 @@ public class User {
 	public void updateByRiotAccount(RiotAccount riotAccount) {
 		this.actualUserId = riotAccount.getMember().getId();
 		this.name = riotAccount.getName();
-		this.internalName = riotAccount.getInternalName();
 		this.tagLine = riotAccount.getTagLine();
 		this.internalTagName = riotAccount.getInternalTagName();
 		this.profileIconId = riotAccount.getIconId();

--- a/src/main/java/com/gnimty/communityapiserver/domain/chat/repository/User/UserRepositoryImpl.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/chat/repository/User/UserRepositoryImpl.java
@@ -26,14 +26,27 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
 		for (User user : users) {
 			Query query = new Query(Criteria.where("actualUserId").is(user.getActualUserId()));
 			Update update = new Update()
+				.set("name", user.getName())
+				.set("internalName", user.getInternalName())
+				.set("tagLine", user.getTagLine())
+				.set("internalTagName", user.getInternalTagName())
+				.set("status", user.getStatus())
 				.set("profileIconId", user.getProfileIconId())
+				.set("puuid", user.getPuuid())
+				// 솔로 랭크
 				.set("tier", user.getTier())
 				.set("division", user.getDivision())
 				.set("lp", user.getLp())
-				.set("name", user.getName())
-				.set("tagLine", user.getTagLine())
+				.set("mmr", user.getMmr())
 				.set("mostLanes", user.getMostLanes())
-				.set("mostChampions", user.getMostChampions());
+				.set("mostChampions", user.getMostChampions())
+				// 자유 랭크
+				.set("tier", user.getTierFlex())
+				.set("division", user.getDivisionFlex())
+				.set("lp", user.getLpFlex())
+				.set("mmr", user.getMmrFlex())
+				.set("mostLanes", user.getMostLanesFlex())
+				.set("mostChampions", user.getMostChampionsFlex());
 
 			bulkOperations.updateOne(query, update);
 		}

--- a/src/main/java/com/gnimty/communityapiserver/domain/chat/repository/User/UserRepositoryImpl.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/chat/repository/User/UserRepositoryImpl.java
@@ -27,7 +27,6 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
 			Query query = new Query(Criteria.where("actualUserId").is(user.getActualUserId()));
 			Update update = new Update()
 				.set("name", user.getName())
-				.set("internalName", user.getInternalName())
 				.set("tagLine", user.getTagLine())
 				.set("internalTagName", user.getInternalTagName())
 				.set("status", user.getStatus())

--- a/src/main/java/com/gnimty/communityapiserver/domain/chat/service/UserService.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/chat/service/UserService.java
@@ -49,13 +49,10 @@ public class UserService {
 	}
 
 
-	public User save(User user) {
-		return userRepository.findByActualUserId(user.getActualUserId())
-			.map(existingUser -> {
-				existingUser.updateByUser(user);
-				return userRepository.save(existingUser);
-			})
-			.orElseGet(() -> userRepository.save(user));
+	public User save(User updatedUser) {
+		findAllUser(updatedUser.getActualUserId())
+			.orElseThrow(() -> new BaseException(ErrorCode.NOT_FOUND_CHAT_USER));
+		return userRepository.save(updatedUser);
 	}
 
 	public BulkWriteResult updateMany(List<User> users) {


### PR DESCRIPTION
1.user 엔티티 수정
- 자유랭크 필드 포함함
- updateUser(User) 삭제함 
   전: User의 필드를 변경 후 userService에서 userId로 찾은 User에 updateUser()를 하고 save() 함.
   후: User의 필드를 변경 후 userService에서 save(user) 함. (만약 userId로 찾지 못하면 오류)
   따라서 updateUser(User)가 필요 없어져서 삭제함. (그리고 채팅 서비스에서는 User의 필드 중 접속상태만 변경 가능함)

2. userService 테스트 수정
- User로 저장 삭제
   채팅 서비스에서 자체적으로 user로 저장하지 않아야 함. 
- User가 없는 상태에서 user를 저장하면 실패 테스트 추가