### PR TITLE
Feat/#115 챔피언 운용법 report

### DIFF
--- a/src/main/java/com/gnimty/communityapiserver/domain/championcommentsreport/controller/ChampionCommentsReportController.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/championcommentsreport/controller/ChampionCommentsReportController.java
@@ -1,0 +1,35 @@
+package com.gnimty.communityapiserver.domain.championcommentsreport.controller;
+
+import static com.gnimty.communityapiserver.global.constant.ResponseMessage.*;
+import static org.springframework.http.HttpStatus.*;
+
+import com.gnimty.communityapiserver.domain.championcommentsreport.controller.dto.request.ChampionCommentsReportRequest;
+import com.gnimty.communityapiserver.domain.championcommentsreport.service.ChampionCommentsReportService;
+import com.gnimty.communityapiserver.global.response.CommonResponse;
+import javax.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/champions/{champion_id}/comments/{comments_id}/report")
+public class ChampionCommentsReportController {
+
+	private final ChampionCommentsReportService championCommentsReportService;
+
+	@ResponseStatus(CREATED)
+	@PostMapping
+	public CommonResponse<Void> doReport(
+		@PathVariable("champion_id") Long championId,
+		@PathVariable("comments_id") Long commentsId,
+		@Valid @RequestBody ChampionCommentsReportRequest request
+	) {
+		championCommentsReportService.doReport(championId, commentsId, request.toServiceRequest());
+		return CommonResponse.success(SUCCESS_COMMENTS_REPORT, CREATED);
+	}
+}

--- a/src/main/java/com/gnimty/communityapiserver/domain/championcommentsreport/controller/dto/request/ChampionCommentsReportRequest.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/championcommentsreport/controller/dto/request/ChampionCommentsReportRequest.java
@@ -1,0 +1,28 @@
+package com.gnimty.communityapiserver.domain.championcommentsreport.controller.dto.request;
+
+import com.gnimty.communityapiserver.domain.championcommentsreport.service.dto.request.ChampionCommentsReportServiceRequest;
+import com.gnimty.communityapiserver.global.constant.ReportType;
+import com.gnimty.communityapiserver.global.exception.ErrorCode.ErrorMessage;
+import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChampionCommentsReportRequest {
+
+	@NotNull(message = ErrorMessage.INVALID_INPUT_VALUE)
+	private ReportType reportType;
+	private String reportComment;
+
+	public ChampionCommentsReportServiceRequest toServiceRequest() {
+		return ChampionCommentsReportServiceRequest.builder()
+			.reportType(reportType)
+			.reportComment(reportComment)
+			.build();
+	}
+}

--- a/src/main/java/com/gnimty/communityapiserver/domain/championcommentsreport/entity/ChampionCommentsReport.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/championcommentsreport/entity/ChampionCommentsReport.java
@@ -1,0 +1,60 @@
+package com.gnimty.communityapiserver.domain.championcommentsreport.entity;
+
+import com.gnimty.communityapiserver.domain.base.entity.BaseEntity;
+import com.gnimty.communityapiserver.domain.championcomments.entity.ChampionComments;
+import com.gnimty.communityapiserver.domain.member.entity.Member;
+import com.gnimty.communityapiserver.global.constant.ReportType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import javax.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "champion_comments_report")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChampionCommentsReport extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "champion_comments_report_id", columnDefinition = "BIGINT", unique = true, nullable = false)
+	private Long id;
+
+	@NotNull
+	@Column(name = "report_type", columnDefinition = "VARCHAR(100)")
+	private ReportType reportType;
+
+	@Column(name = "report_comment", columnDefinition = "VARCHAR(100)")
+	private String reportComment;
+
+	@ManyToOne(fetch = FetchType.LAZY, optional = false)
+	@JoinColumn(name = "champion_comments_id", nullable = false)
+	private ChampionComments championComments;
+
+	@ManyToOne(fetch = FetchType.LAZY, optional = false)
+	@JoinColumn(name = "member_id", nullable = false)
+	private Member member;
+
+	@Builder
+	public ChampionCommentsReport(
+		ReportType reportType,
+		String reportComment,
+		ChampionComments championComments,
+		Member member
+	) {
+		this.reportType = reportType;
+		this.reportComment = reportComment;
+		this.championComments = championComments;
+		this.member = member;
+	}
+}

--- a/src/main/java/com/gnimty/communityapiserver/domain/championcommentsreport/reposiotry/ChampionCommentsReportQueryRepository.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/championcommentsreport/reposiotry/ChampionCommentsReportQueryRepository.java
@@ -1,0 +1,32 @@
+package com.gnimty.communityapiserver.domain.championcommentsreport.reposiotry;
+
+import static com.gnimty.communityapiserver.domain.championcommentsreport.entity.QChampionCommentsReport.championCommentsReport;
+
+import com.gnimty.communityapiserver.domain.championcomments.entity.ChampionComments;
+import com.gnimty.communityapiserver.domain.member.entity.Member;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class ChampionCommentsReportQueryRepository {
+
+	private final JPAQueryFactory queryFactory;
+
+	public boolean existsByMemberAndChampionComments(Member member, ChampionComments championComments) {
+		return queryFactory.selectOne()
+			.from(championCommentsReport)
+			.where(memberIdEq(member), championCommentsIdEq(championComments))
+			.fetchFirst() != null;
+	}
+
+	private BooleanExpression championCommentsIdEq(ChampionComments championComments) {
+		return championCommentsReport.championComments.id.eq(championComments.getId());
+	}
+
+	private BooleanExpression memberIdEq(Member member) {
+		return championCommentsReport.member.id.eq(member.getId());
+	}
+}

--- a/src/main/java/com/gnimty/communityapiserver/domain/championcommentsreport/reposiotry/ChampionCommentsReportRepository.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/championcommentsreport/reposiotry/ChampionCommentsReportRepository.java
@@ -1,0 +1,7 @@
+package com.gnimty.communityapiserver.domain.championcommentsreport.reposiotry;
+
+import com.gnimty.communityapiserver.domain.championcommentsreport.entity.ChampionCommentsReport;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChampionCommentsReportRepository extends JpaRepository<ChampionCommentsReport, Long> {
+}

--- a/src/main/java/com/gnimty/communityapiserver/domain/championcommentsreport/service/ChampionCommentsReportService.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/championcommentsreport/service/ChampionCommentsReportService.java
@@ -10,6 +10,7 @@ import com.gnimty.communityapiserver.domain.championcommentsreport.reposiotry.Ch
 import com.gnimty.communityapiserver.domain.championcommentsreport.service.dto.request.ChampionCommentsReportServiceRequest;
 import com.gnimty.communityapiserver.domain.member.entity.Member;
 import com.gnimty.communityapiserver.global.auth.MemberThreadLocal;
+import com.gnimty.communityapiserver.global.constant.ReportType;
 import com.gnimty.communityapiserver.global.exception.BaseException;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
@@ -27,9 +28,7 @@ public class ChampionCommentsReportService {
 
 	public void doReport(Long championId, Long commentsId, ChampionCommentsReportServiceRequest request) {
 		Member member = MemberThreadLocal.get();
-		if (!member.getRsoLinked()) {
-			throw new BaseException(NOT_LINKED_RSO);
-		}
+		validationReport(request, member);
 		ChampionComments championComments = championCommentsReadService.findById(commentsId);
 		if (championCommentsReportQueryRepository.existsByMemberAndChampionComments(member, championComments)) {
 			throw new BaseException(DUPLICATED_REPORT);
@@ -44,5 +43,14 @@ public class ChampionCommentsReportService {
 				.reportComment(request.getReportComment())
 				.member(member)
 				.build());
+	}
+
+	private void validationReport(ChampionCommentsReportServiceRequest request, Member member) {
+		if (!member.getRsoLinked()) {
+			throw new BaseException(NOT_LINKED_RSO);
+		}
+		if (request.getReportType().equals(ReportType.OTHER) && request.getReportComment() == null) {
+			throw new BaseException(OTHER_TYPE_MUST_CONTAIN_COMMENT);
+		}
 	}
 }

--- a/src/main/java/com/gnimty/communityapiserver/domain/championcommentsreport/service/ChampionCommentsReportService.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/championcommentsreport/service/ChampionCommentsReportService.java
@@ -1,0 +1,48 @@
+package com.gnimty.communityapiserver.domain.championcommentsreport.service;
+
+import static com.gnimty.communityapiserver.global.exception.ErrorCode.*;
+
+import com.gnimty.communityapiserver.domain.championcomments.entity.ChampionComments;
+import com.gnimty.communityapiserver.domain.championcomments.service.ChampionCommentsReadService;
+import com.gnimty.communityapiserver.domain.championcommentsreport.entity.ChampionCommentsReport;
+import com.gnimty.communityapiserver.domain.championcommentsreport.reposiotry.ChampionCommentsReportQueryRepository;
+import com.gnimty.communityapiserver.domain.championcommentsreport.reposiotry.ChampionCommentsReportRepository;
+import com.gnimty.communityapiserver.domain.championcommentsreport.service.dto.request.ChampionCommentsReportServiceRequest;
+import com.gnimty.communityapiserver.domain.member.entity.Member;
+import com.gnimty.communityapiserver.global.auth.MemberThreadLocal;
+import com.gnimty.communityapiserver.global.exception.BaseException;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@Service
+@RequiredArgsConstructor
+public class ChampionCommentsReportService {
+
+	private final ChampionCommentsReportRepository championCommentsReportRepository;
+	private final ChampionCommentsReadService championCommentsReadService;
+	private final ChampionCommentsReportQueryRepository championCommentsReportQueryRepository;
+
+	public void doReport(Long championId, Long commentsId, ChampionCommentsReportServiceRequest request) {
+		Member member = MemberThreadLocal.get();
+		if (!member.getRsoLinked()) {
+			throw new BaseException(NOT_LINKED_RSO);
+		}
+		ChampionComments championComments = championCommentsReadService.findById(commentsId);
+		if (championCommentsReportQueryRepository.existsByMemberAndChampionComments(member, championComments)) {
+			throw new BaseException(DUPLICATED_REPORT);
+		}
+		if (!Objects.equals(championId, championComments.getChampionId())) {
+			throw new BaseException(COMMENTS_ID_AND_CHAMPION_ID_INVALID);
+		}
+		championCommentsReportRepository.save(
+			ChampionCommentsReport.builder()
+				.championComments(championComments)
+				.reportType(request.getReportType())
+				.reportComment(request.getReportComment())
+				.member(member)
+				.build());
+	}
+}

--- a/src/main/java/com/gnimty/communityapiserver/domain/championcommentsreport/service/dto/request/ChampionCommentsReportServiceRequest.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/championcommentsreport/service/dto/request/ChampionCommentsReportServiceRequest.java
@@ -1,0 +1,13 @@
+package com.gnimty.communityapiserver.domain.championcommentsreport.service.dto.request;
+
+import com.gnimty.communityapiserver.global.constant.ReportType;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class ChampionCommentsReportServiceRequest {
+
+	private ReportType reportType;
+	private String reportComment;
+}

--- a/src/main/java/com/gnimty/communityapiserver/global/constant/ReportType.java
+++ b/src/main/java/com/gnimty/communityapiserver/global/constant/ReportType.java
@@ -1,0 +1,27 @@
+package com.gnimty.communityapiserver.global.constant;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.gnimty.communityapiserver.global.exception.BaseException;
+import com.gnimty.communityapiserver.global.exception.ErrorCode;
+import java.util.stream.Stream;
+import lombok.Getter;
+
+@Getter
+public enum ReportType {
+
+	ABUSE,
+	OBSCENE,
+	FALSEHOOD,
+	SPAMMING,
+	ILLEGAL_ADVERTISING,
+	PERSONAL_INFORMATION_EXPOSURE,
+	OTHER;
+
+	@JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+	public static ReportType findByInput(String input) {
+		return Stream.of(ReportType.values())
+			.filter(c -> c.name().equals(input))
+			.findFirst()
+			.orElseThrow(() -> new BaseException(ErrorCode.INVALID_ENUM_VALUE));
+	}
+}

--- a/src/main/java/com/gnimty/communityapiserver/global/constant/ResponseMessage.java
+++ b/src/main/java/com/gnimty/communityapiserver/global/constant/ResponseMessage.java
@@ -26,7 +26,8 @@ public enum ResponseMessage {
 	SUCCESS_ADD_CHAMPION_COMMENTS("성공적으로 챔피언 운용법을 작성했습니다."),
 	SUCCESS_UPDATE_CHAMPION_COMMENTS("성공적으로 챔피언 운용법을 수정했습니다."),
 	SUCCESS_DELETE_CHAMPION_COMMENTS("성공적으로 챔피언 운용법을 삭제했습니다."),
-	SUCCESS_CHAMPION_COMMENTS_LIKE("성공적으로 챔피언 운용법 좋아요/싫어요에 대한 수정을 완료하였습니다.");
+	SUCCESS_CHAMPION_COMMENTS_LIKE("성공적으로 챔피언 운용법 좋아요/싫어요에 대한 수정을 완료하였습니다."),
+	SUCCESS_COMMENTS_REPORT("성공적으로 챔피언 운용법에 대한 신고를 완료하였습니다.");
 
 	private final String message;
 

--- a/src/main/java/com/gnimty/communityapiserver/global/exception/ErrorCode.java
+++ b/src/main/java/com/gnimty/communityapiserver/global/exception/ErrorCode.java
@@ -68,6 +68,7 @@ public enum ErrorCode {
 	INVALID_VERSION(BAD_REQUEST, ErrorMessage.INVALID_VERSION),
 	INVALID_CHILD_COMMENTS(BAD_REQUEST, ErrorMessage.INVALID_CHILD_COMMENTS),
 	DUPLICATED_REPORT(CONFLICT, ErrorMessage.DUPLICATED_REPORT),
+	OTHER_TYPE_MUST_CONTAIN_COMMENT(BAD_REQUEST, ErrorMessage.OTHER_TYPE_MUST_CONTAIN_COMMENT),
 
 	// server
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Server Error");
@@ -136,5 +137,6 @@ public enum ErrorCode {
 		public static final String INVALID_VERSION = "답글 작성 시, 상위 답글과의 버전 정보가 동일해야합니다.";
 		public static final String INVALID_CHILD_COMMENTS = "하위 댓글 또는 답글은 카테고리, 포지션, 상대 챔피언을 선택할 수 없습니다.";
 		public static final String DUPLICATED_REPORT = "한 댓글에 한 번의 신고만 허용됩니다.";
+		public static final String OTHER_TYPE_MUST_CONTAIN_COMMENT = "기타 타입의 신고 사유는 상세 신고 사유를 반드시 작성해야 합니다.";
 	}
 }

--- a/src/main/java/com/gnimty/communityapiserver/global/exception/ErrorCode.java
+++ b/src/main/java/com/gnimty/communityapiserver/global/exception/ErrorCode.java
@@ -67,6 +67,7 @@ public enum ErrorCode {
 	INVALID_UUID(BAD_REQUEST, ErrorMessage.INVALID_UUID),
 	INVALID_VERSION(BAD_REQUEST, ErrorMessage.INVALID_VERSION),
 	INVALID_CHILD_COMMENTS(BAD_REQUEST, ErrorMessage.INVALID_CHILD_COMMENTS),
+	DUPLICATED_REPORT(CONFLICT, ErrorMessage.DUPLICATED_REPORT),
 
 	// server
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Server Error");
@@ -134,5 +135,6 @@ public enum ErrorCode {
 		public static final String INVALID_UUID = "올바르지 않은 uuid입니다.";
 		public static final String INVALID_VERSION = "답글 작성 시, 상위 답글과의 버전 정보가 동일해야합니다.";
 		public static final String INVALID_CHILD_COMMENTS = "하위 댓글 또는 답글은 카테고리, 포지션, 상대 챔피언을 선택할 수 없습니다.";
+		public static final String DUPLICATED_REPORT = "한 댓글에 한 번의 신고만 허용됩니다.";
 	}
 }


### PR DESCRIPTION
Entity에 ReportType과 ReportComment가 있는데, ReportComment는 ReportType을 OTHER(기타)로 지정했을 경우 입력되는 텍스트를 받기 위해 작성했습니다.
이렇게 안하면 기타에 ReportType과 똑같은 텍스트를 입력하면 구별하기 힘들어 지더라구요.

validation은 다음과 같이 진행하였습니다.
1. RSO 연동되지 않았으면 [예외]
2. 신고 타입이 OTHER인데 reportComment를 입력하지 않았으면 [예외]
3. 이미 해당 댓글에 대해 신고한 기록이 있으면 [예외]
4. 기타 field에 대한 validation

this closes #115 