### PR TITLE
Feat: 웹소켓 연결 시 사용자가 선택한 상태값으로 변경

### DIFF
--- a/src/main/java/com/gnimty/communityapiserver/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/chat/controller/ChatController.java
@@ -108,27 +108,27 @@ public class ChatController {
 
 
 	@EventListener
-	public void onClientDisconnect(SessionDisconnectEvent event) {
-		User user = getUserBySessionId(event.getSessionId());
-		log.info("[DisConnect] userId: {}", user.getActualUserId());
-		if (!isMultipleUser(user.getActualUserId())) {
-			stompService.updateConnStatus(user, Status.OFFLINE);
-			memberService.updateStatus(Status.OFFLINE, user.getActualUserId());
-		}
-		webSocketSessionManager.deleteSession(event.getSessionId());
-	}
-
-	@EventListener
 	public void onClientConnect(SessionConnectedEvent event) {
 		String sessionId = String.valueOf(event.getMessage().getHeaders().get("simpSessionId"));
 		User user = getUserBySessionId(sessionId);
 		log.info("[Connect] userId: {}", user.getActualUserId());
 		if (!isMultipleUser(user.getActualUserId())) {
-			stompService.updateConnStatus(user, Status.ONLINE);
-			memberService.updateStatus(Status.ONLINE, user.getActualUserId());
+			stompService.updateConnStatus(user, user.getSelectedStatus(), false);
+			memberService.updateStatus(user.getSelectedStatus(), user.getActualUserId());
 		}
-
 	}
+
+	@EventListener
+	public void onClientDisconnect(SessionDisconnectEvent event) {
+		User user = getUserBySessionId(event.getSessionId());
+		log.info("[DisConnect] userId: {}", user.getActualUserId());
+		if (!isMultipleUser(user.getActualUserId())) {
+			stompService.updateConnStatus(user, Status.OFFLINE, false);
+			memberService.updateStatus(Status.OFFLINE, user.getActualUserId());
+		}
+		webSocketSessionManager.deleteSession(event.getSessionId());
+	}
+
 
 	private User getUserBySessionId(String sessionId) {
 		Long actualUserId = webSocketSessionManager.getMemberId(sessionId);

--- a/src/main/java/com/gnimty/communityapiserver/domain/chat/controller/dto/UserDto.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/chat/controller/dto/UserDto.java
@@ -19,7 +19,7 @@ public class UserDto {
 
 	public UserDto(User user) {
 		this.userId = user.getActualUserId();
-		this.status = user.getStatus();
+		this.status = user.getNowStatus();
 		this.tier = user.getTier();
 		this.division = user.getDivision();
 		this.iconId = user.getProfileIconId();

--- a/src/main/java/com/gnimty/communityapiserver/domain/chat/entity/User.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/chat/entity/User.java
@@ -35,7 +35,8 @@ public class User {
 	private String name;
 	private String tagLine;
 	private String internalTagName;
-	private Status status;
+	private Status nowStatus;
+	private Status selectedStatus;
 	private Long profileIconId;
 	private String puuid;
 
@@ -70,6 +71,7 @@ public class User {
 			.internalTagName(riotAccount.getInternalTagName())
 			.profileIconId(riotAccount.getIconId())
 			.puuid(riotAccount.getPuuid())
+			.selectedStatus(Status.ONLINE)
 			// 솔로 랭크
 			.tier(riotAccount.getQueue())
 			.division(riotAccount.getDivision())
@@ -128,7 +130,12 @@ public class User {
 			.orElse(this.frequentChampionId3Flex);
 	}
 
-	public void updateStatus(Status status) {
-		this.status = status;
+	public void updateNowStatus(Status nowStatus) {
+		this.nowStatus = nowStatus;
 	}
+
+	public void updateSelectedStatus(Status selectedStatus){
+		this.selectedStatus = selectedStatus;
+	}
+
 }

--- a/src/main/java/com/gnimty/communityapiserver/domain/chat/entity/User.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/chat/entity/User.java
@@ -134,7 +134,7 @@ public class User {
 		this.nowStatus = nowStatus;
 	}
 
-	public void updateSelectedStatus(Status selectedStatus){
+	public void updateSelectedStatus(Status selectedStatus) {
 		this.selectedStatus = selectedStatus;
 	}
 

--- a/src/main/java/com/gnimty/communityapiserver/domain/chat/repository/User/UserRepositoryImpl.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/chat/repository/User/UserRepositoryImpl.java
@@ -29,7 +29,7 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
 			setIfNotNull(update, "name", user.getName());
 			setIfNotNull(update, "tagLine", user.getTagLine());
 			setIfNotNull(update, "internalTagName", user.getInternalTagName());
-			setIfNotNull(update, "status", user.getStatus());
+			setIfNotNull(update, "status", user.getNowStatus());
 			setIfNotNull(update, "profileIconId", user.getProfileIconId());
 			setIfNotNull(update, "puuid", user.getPuuid());
 			// 솔로 랭크

--- a/src/main/java/com/gnimty/communityapiserver/domain/chat/service/StompService.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/chat/service/StompService.java
@@ -203,8 +203,11 @@ public class StompService {
 
 
 	// TODO janguni: 접속정보 변동내역 전송
-	public void updateConnStatus(User user, Status connectStatus) {
-		user.updateStatus(connectStatus);
+	public void updateConnStatus(User user, Status connectStatus, Boolean isByUser) {
+		user.updateNowStatus(connectStatus);
+		if (connectStatus.equals(Status.OFFLINE) && isByUser) {
+			user.updateSelectedStatus(connectStatus);
+		}
 		userService.save(user);
 
 		List<ChatRoom> chatRooms = chatRoomService.findChatRoom(user);

--- a/src/main/java/com/gnimty/communityapiserver/domain/member/controller/MemberController.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/member/controller/MemberController.java
@@ -115,7 +115,8 @@ public class MemberController {
 	public CommonResponse<Void> updateMyProfileMain(@RequestBody @Valid MyProfileMainUpdateRequest request) {
 		RiotAccount riotAccount = memberService.updateMyProfileMain(request.toServiceRequest());
 		if (request.getStatus() != null) {
-			stompService.updateConnStatus(userService.getUser(MemberThreadLocal.get().getId()), request.getStatus(), true);
+			stompService.updateConnStatus(userService.getUser(MemberThreadLocal.get().getId()), request.getStatus(),
+				true);
 		}
 		if (riotAccount != null) {
 			stompService.createOrUpdateUser(riotAccount);

--- a/src/main/java/com/gnimty/communityapiserver/domain/member/controller/MemberController.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/member/controller/MemberController.java
@@ -115,7 +115,7 @@ public class MemberController {
 	public CommonResponse<Void> updateMyProfileMain(@RequestBody @Valid MyProfileMainUpdateRequest request) {
 		RiotAccount riotAccount = memberService.updateMyProfileMain(request.toServiceRequest());
 		if (request.getStatus() != null) {
-			stompService.updateConnStatus(userService.getUser(MemberThreadLocal.get().getId()), request.getStatus());
+			stompService.updateConnStatus(userService.getUser(MemberThreadLocal.get().getId()), request.getStatus(), true);
 		}
 		if (riotAccount != null) {
 			stompService.createOrUpdateUser(riotAccount);
@@ -160,7 +160,7 @@ public class MemberController {
 	@PatchMapping("/me")
 	public CommonResponse<Void> updateMyProfile(@RequestBody @Valid MyProfileUpdateRequest request) {
 		memberService.updateMyProfile(request.toServiceRequest());
-		stompService.updateConnStatus(userService.getUser(MemberThreadLocal.get().getId()), request.getStatus());
+		stompService.updateConnStatus(userService.getUser(MemberThreadLocal.get().getId()), request.getStatus(), true);
 		return CommonResponse.success(SUCCESS_UPDATE_PROFILE, OK);
 	}
 

--- a/src/test/java/com/gnimty/communityapiserver/controller/member/MemberControllerTest.java
+++ b/src/test/java/com/gnimty/communityapiserver/controller/member/MemberControllerTest.java
@@ -309,7 +309,7 @@ public class MemberControllerTest extends ControllerTestSupport {
 				.willReturn(null);
 			willDoNothing()
 				.given(stompService)
-				.updateConnStatus(any(User.class), any(Status.class));
+				.updateConnStatus(any(User.class), any(Status.class), true);
 			willDoNothing()
 				.given(stompService)
 				.createOrUpdateUser(any(RiotAccount.class));
@@ -337,7 +337,7 @@ public class MemberControllerTest extends ControllerTestSupport {
 				.willReturn(null);
 			willDoNothing()
 				.given(stompService)
-				.updateConnStatus(any(User.class), any(Status.class));
+				.updateConnStatus(any(User.class), any(Status.class), true);
 			willDoNothing()
 				.given(stompService)
 				.createOrUpdateUser(any(RiotAccount.class));
@@ -361,7 +361,7 @@ public class MemberControllerTest extends ControllerTestSupport {
 				.willReturn(null);
 			willDoNothing()
 				.given(stompService)
-				.updateConnStatus(any(User.class), any(Status.class));
+				.updateConnStatus(any(User.class), any(Status.class), true);
 			willDoNothing()
 				.given(stompService)
 				.createOrUpdateUser(any(RiotAccount.class));
@@ -686,7 +686,7 @@ public class MemberControllerTest extends ControllerTestSupport {
 					.updateMyProfile(any(MyProfileUpdateServiceRequest.class));
 				willDoNothing()
 					.given(stompService)
-					.updateConnStatus(any(User.class), any(Status.class));
+					.updateConnStatus(any(User.class), any(Status.class), true);
 
 				mockMvc.perform(patch(REQUEST_URL)
 						.content(om.writeValueAsString(request))
@@ -709,7 +709,7 @@ public class MemberControllerTest extends ControllerTestSupport {
 				.updateMyProfile(any(MyProfileUpdateServiceRequest.class));
 			willDoNothing()
 				.given(stompService)
-				.updateConnStatus(any(User.class), any(Status.class));
+				.updateConnStatus(any(User.class), any(Status.class), true);
 
 			mockMvc.perform(patch(REQUEST_URL)
 					.content(om.writeValueAsString(request))
@@ -732,7 +732,7 @@ public class MemberControllerTest extends ControllerTestSupport {
 				.updateMyProfile(any(MyProfileUpdateServiceRequest.class));
 			willDoNothing()
 				.given(stompService)
-				.updateConnStatus(any(User.class), any(Status.class));
+				.updateConnStatus(any(User.class), any(Status.class), true);
 
 			mockMvc.perform(patch(REQUEST_URL)
 					.content(om.writeValueAsString(request))
@@ -758,7 +758,7 @@ public class MemberControllerTest extends ControllerTestSupport {
 				.updateMyProfile(any(MyProfileUpdateServiceRequest.class));
 			willDoNothing()
 				.given(stompService)
-				.updateConnStatus(any(User.class), any(Status.class));
+				.updateConnStatus(any(User.class), any(Status.class), true);
 
 			mockMvc.perform(patch(REQUEST_URL)
 					.content(om.writeValueAsString(request))
@@ -784,7 +784,7 @@ public class MemberControllerTest extends ControllerTestSupport {
 				.updateMyProfile(any(MyProfileUpdateServiceRequest.class));
 			willDoNothing()
 				.given(stompService)
-				.updateConnStatus(any(User.class), any(Status.class));
+				.updateConnStatus(any(User.class), any(Status.class), true);
 
 			mockMvc.perform(patch(REQUEST_URL)
 					.content(om.writeValueAsString(request))
@@ -807,7 +807,7 @@ public class MemberControllerTest extends ControllerTestSupport {
 				.updateMyProfile(any(MyProfileUpdateServiceRequest.class));
 			willDoNothing()
 				.given(stompService)
-				.updateConnStatus(any(User.class), any(Status.class));
+				.updateConnStatus(any(User.class), any(Status.class), true);
 
 			mockMvc.perform(patch(REQUEST_URL)
 					.content(om.writeValueAsString(request))
@@ -830,7 +830,7 @@ public class MemberControllerTest extends ControllerTestSupport {
 				.updateMyProfile(any(MyProfileUpdateServiceRequest.class));
 			willDoNothing()
 				.given(stompService)
-				.updateConnStatus(any(User.class), any(Status.class));
+				.updateConnStatus(any(User.class), any(Status.class), true);
 
 			mockMvc.perform(patch(REQUEST_URL)
 					.content(om.writeValueAsString(request))
@@ -855,7 +855,7 @@ public class MemberControllerTest extends ControllerTestSupport {
 				.updateMyProfile(any(MyProfileUpdateServiceRequest.class));
 			willDoNothing()
 				.given(stompService)
-				.updateConnStatus(any(User.class), any(Status.class));
+				.updateConnStatus(any(User.class), any(Status.class), true);
 
 			mockMvc.perform(patch(REQUEST_URL)
 					.content(om.writeValueAsString(request))
@@ -878,7 +878,7 @@ public class MemberControllerTest extends ControllerTestSupport {
 				.updateMyProfile(any(MyProfileUpdateServiceRequest.class));
 			willDoNothing()
 				.given(stompService)
-				.updateConnStatus(any(User.class), any(Status.class));
+				.updateConnStatus(any(User.class), any(Status.class), true);
 
 			mockMvc.perform(patch(REQUEST_URL)
 					.content(om.writeValueAsString(request))

--- a/src/test/java/com/gnimty/communityapiserver/controller/member/MemberControllerTest.java
+++ b/src/test/java/com/gnimty/communityapiserver/controller/member/MemberControllerTest.java
@@ -1,6 +1,5 @@
 package com.gnimty.communityapiserver.controller.member;
 
-import static com.gnimty.communityapiserver.global.constant.ResponseMessage.SUCCESS_BLOCK;
 import static com.gnimty.communityapiserver.global.constant.ResponseMessage.SUCCESS_DISCONNECT_OAUTH;
 import static com.gnimty.communityapiserver.global.constant.ResponseMessage.SUCCESS_GOOGLE_LINK;
 import static com.gnimty.communityapiserver.global.constant.ResponseMessage.SUCCESS_KAKAO_LINK;

--- a/src/test/java/com/gnimty/communityapiserver/domain/chat/service/ChatRoomServiceTest.java
+++ b/src/test/java/com/gnimty/communityapiserver/domain/chat/service/ChatRoomServiceTest.java
@@ -391,7 +391,7 @@ class ChatRoomServiceTest {
 			.division(3)
 			.name(name)
 			.tagLine("tagLine")
-			.status(Status.ONLINE).lp(3L)
+			.nowStatus(Status.ONLINE).lp(3L)
 			.build();
 	}
 

--- a/src/test/java/com/gnimty/communityapiserver/domain/chat/service/ChatServiceTest.java
+++ b/src/test/java/com/gnimty/communityapiserver/domain/chat/service/ChatServiceTest.java
@@ -120,7 +120,7 @@ class ChatServiceTest {
 				.division(3)
 				.name("uni")
 				.tagLine("tag")
-				.status(Status.ONLINE)
+				.nowStatus(Status.ONLINE)
 				.lp(3L).build();
 			userRepository.save(user);
 

--- a/src/test/java/com/gnimty/communityapiserver/domain/chat/service/StompServiceTest.java
+++ b/src/test/java/com/gnimty/communityapiserver/domain/chat/service/StompServiceTest.java
@@ -372,7 +372,6 @@ public class StompServiceTest {
 				Chat.builder().senderId(userB.getActualUserId()).sendDate(new Date()).message("bye")
 					.chatRoomNo(chatRoom.getChatRoomNo()).build());
 
-
 			Participant participantUserA = stompService.extractParticipant(userA,
 				chatRoom.getParticipants(), true);
 			Thread.sleep(2000);
@@ -382,7 +381,6 @@ public class StompServiceTest {
 
 			// when
 			List<ChatDto> chats = stompService.getChatList(userA, chatRoom);
-
 
 			// then
 			assertThat(chats).isEmpty();
@@ -698,7 +696,7 @@ public class StompServiceTest {
 
 			// then
 			assertThat(chatRoomRepository.findByUsers(userA, userB)).isEmpty();
-			assertThat(chatRepository.findByChatRoomNo(chatRoom.getChatRoomNo(),ChatDto.class)).isEmpty();
+			assertThat(chatRepository.findByChatRoomNo(chatRoom.getChatRoomNo(), ChatDto.class)).isEmpty();
 		}
 
 
@@ -878,7 +876,7 @@ public class StompServiceTest {
 			// then
 			assertThat(userRepository.findByActualUserId(userA.getActualUserId())).isEmpty();
 			assertThat(chatRoomRepository.findByUser(userA)).isEmpty();
-			assertThat(chatRepository.findByChatRoomNo(chatRoom.getChatRoomNo(),ChatDto.class)).isEmpty();
+			assertThat(chatRepository.findByChatRoomNo(chatRoom.getChatRoomNo(), ChatDto.class)).isEmpty();
 		}
 
 		@DisplayName("유효하지 않은 userId여도 아무일도 일어나지 않음")

--- a/src/test/java/com/gnimty/communityapiserver/domain/chat/service/StompServiceTest.java
+++ b/src/test/java/com/gnimty/communityapiserver/domain/chat/service/StompServiceTest.java
@@ -39,7 +39,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.util.StopWatch;
 
 
 @Slf4j
@@ -570,11 +569,11 @@ public class StompServiceTest {
 			userRepository.save(userA);
 
 			// when
-			stompService.updateConnStatus(userA, Status.AWAY);
+			stompService.updateConnStatus(userA, Status.AWAY, true);
 
 			// then
 			User findUserA = userRepository.findByActualUserId(userA.getActualUserId()).get();
-			assertThat(findUserA.getStatus()).isEqualTo(Status.AWAY);
+			assertThat(findUserA.getNowStatus()).isEqualTo(Status.AWAY);
 		}
 	}
 
@@ -1021,21 +1020,21 @@ public class StompServiceTest {
 			assertThat(findUserA.get().getFrequentChampionId1()).isEqualTo(3L);
 			assertThat(findUserA.get().getFrequentChampionId3()).isEqualTo(4L);
 			assertThat(findUserA.get().getFrequentLane1()).isEqualTo(Lane.JUNGLE);
-			assertThat(findUserA.get().getStatus()).isEqualTo(Status.ONLINE);
+			assertThat(findUserA.get().getNowStatus()).isEqualTo(Status.ONLINE);
 
 			Optional<User> findUserB = userRepository.findByActualUserId(userB.getActualUserId());
 			assertThat(findUserB).isPresent();
 			assertThat(findUserB.get().getFrequentChampionId1()).isEqualTo(3L);
 			assertThat(findUserB.get().getFrequentChampionId3()).isEqualTo(4L);
 			assertThat(findUserB.get().getFrequentLane1()).isEqualTo(Lane.JUNGLE);
-			assertThat(findUserB.get().getStatus()).isEqualTo(Status.ONLINE);
+			assertThat(findUserB.get().getNowStatus()).isEqualTo(Status.ONLINE);
 
 			Optional<User> findUserC = userRepository.findByActualUserId(userC.getActualUserId());
 			assertThat(findUserC).isPresent();
 			assertThat(findUserC.get().getFrequentChampionId1()).isEqualTo(3L);
 			assertThat(findUserC.get().getFrequentChampionId3()).isEqualTo(4L);
 			assertThat(findUserC.get().getFrequentLane1()).isEqualTo(Lane.JUNGLE);
-			assertThat(findUserC.get().getStatus()).isEqualTo(Status.ONLINE);
+			assertThat(findUserC.get().getNowStatus()).isEqualTo(Status.ONLINE);
 		}
 
 		@DisplayName("유저들 중 존재 하지 않는 user가 있다면 저장, 나머지는 수정")
@@ -1076,7 +1075,7 @@ public class StompServiceTest {
 			Optional<User> findUserA = userRepository.findByActualUserId(memberA.getId());
 			assertThat(findUserA).isPresent();
 			assertThat(findUserA.get().getFrequentChampionId1()).isEqualTo(3L);
-			assertThat(findUserA.get().getStatus()).isEqualTo(Status.ONLINE);
+			assertThat(findUserA.get().getNowStatus()).isEqualTo(Status.ONLINE);
 
 			Optional<User> findUserB = userRepository.findByActualUserId(memberB.getId());
 			assertThat(findUserB).isPresent();
@@ -1095,7 +1094,7 @@ public class StompServiceTest {
 			.division(3)
 			.name(name)
 			.tagLine("tagLine")
-			.status(Status.ONLINE).lp(3L)
+			.nowStatus(Status.ONLINE).lp(3L)
 			.build();
 	}
 }

--- a/src/test/java/com/gnimty/communityapiserver/domain/chat/service/UserServiceTest.java
+++ b/src/test/java/com/gnimty/communityapiserver/domain/chat/service/UserServiceTest.java
@@ -69,7 +69,7 @@ class UserServiceTest {
 				.division(3)
 				.name("uni")
 				.tagLine("tag")
-				.status(Status.ONLINE)
+				.nowStatus(Status.ONLINE)
 				.lp(3L).build();
 			userRepository.save(user);
 
@@ -120,7 +120,7 @@ class UserServiceTest {
 				.division(3)
 				.name("uni")
 				.tagLine("tag")
-				.status(Status.ONLINE)
+				.nowStatus(Status.ONLINE)
 				.lp(3L).build();
 			userRepository.save(user);
 
@@ -165,7 +165,7 @@ class UserServiceTest {
 					.actualUserId(i.longValue())
 					.tier(Tier.diamond)
 					.lp(1L)
-					.status(Status.ONLINE)
+					.nowStatus(Status.ONLINE)
 					.name("name" + i)
 					.tagLine("tag")
 					.profileIconId(1L)
@@ -226,7 +226,7 @@ class UserServiceTest {
 				.actualUserId(member.getId())
 				.tier(Tier.diamond)
 				.lp(1L)
-				.status(Status.ONLINE)
+				.nowStatus(Status.ONLINE)
 				.name("uni")
 				.tagLine("tag")
 				.profileIconId(1L)
@@ -251,7 +251,7 @@ class UserServiceTest {
 			assertThat(savedUser.getFrequentChampionId2()).isEqualTo(2L);
 			assertThat(savedUser.getFrequentChampionId3()).isEqualTo(3L);
 			assertThat(savedUser.getActualUserId()).isEqualTo(member.getId());
-			assertThat(savedUser.getStatus()).isEqualTo(Status.ONLINE);
+			assertThat(savedUser.getNowStatus()).isEqualTo(Status.ONLINE);
 		}
 
 
@@ -263,7 +263,7 @@ class UserServiceTest {
 				.actualUserId(1L)
 				.tier(Tier.diamond)
 				.lp(1L)
-				.status(Status.ONLINE)
+				.nowStatus(Status.ONLINE)
 				.name("uni")
 				.tagLine("tag")
 				.profileIconId(1L)
@@ -280,7 +280,7 @@ class UserServiceTest {
 			User findUser = userRepository.findByActualUserId(1L).get();
 			assertThat(findUser.getTier()).isEqualTo(Tier.diamond);
 			assertThat(findUser.getName()).isEqualTo("uni");
-			assertThat(findUser.getStatus()).isEqualTo(Status.AWAY);
+			assertThat(findUser.getNowStatus()).isEqualTo(Status.AWAY);
 		}
 
 		@DisplayName("user가 없는 상태에서 user를 저장하면 실패")
@@ -291,7 +291,7 @@ class UserServiceTest {
 				.actualUserId(1L)
 				.tier(Tier.diamond)
 				.lp(1L)
-				.status(Status.ONLINE)
+				.nowStatus(Status.ONLINE)
 				.name("uni")
 				.tagLine("tag")
 				.profileIconId(1L)
@@ -337,15 +337,15 @@ class UserServiceTest {
 			// then
 			Optional<User> findUserA = userRepository.findByActualUserId(userA.getActualUserId());
 			assertThat(findUserA).isPresent();
-			assertThat(findUserA.get().getStatus()).isEqualTo(Status.AWAY);
+			assertThat(findUserA.get().getNowStatus()).isEqualTo(Status.AWAY);
 
 			Optional<User> findUserB = userRepository.findByActualUserId(userB.getActualUserId());
 			assertThat(findUserB).isPresent();
-			assertThat(findUserB.get().getStatus()).isEqualTo(Status.AWAY);
+			assertThat(findUserB.get().getNowStatus()).isEqualTo(Status.AWAY);
 
 			Optional<User> findUserC = userRepository.findByActualUserId(userC.getActualUserId());
 			assertThat(findUserC).isPresent();
-			assertThat(findUserC.get().getStatus()).isEqualTo(Status.AWAY);
+			assertThat(findUserC.get().getNowStatus()).isEqualTo(Status.AWAY);
 		}
 
 		@DisplayName("존재하지 않은 User가 있다면 패스, 존재하는 User는 수정")
@@ -371,11 +371,11 @@ class UserServiceTest {
 			// then
 			Optional<User> findUserA = userRepository.findByActualUserId(userA.getActualUserId());
 			assertThat(findUserA).isPresent();
-			assertThat(findUserA.get().getStatus()).isEqualTo(Status.AWAY);
+			assertThat(findUserA.get().getNowStatus()).isEqualTo(Status.AWAY);
 
 			Optional<User> findUserB = userRepository.findByActualUserId(userB.getActualUserId());
 			assertThat(findUserB).isPresent();
-			assertThat(findUserB.get().getStatus()).isEqualTo(Status.AWAY);
+			assertThat(findUserB.get().getNowStatus()).isEqualTo(Status.AWAY);
 
 			Optional<User> findUserC = userRepository.findByActualUserId(userC.getActualUserId());
 			assertThat(findUserC).isEmpty();
@@ -411,7 +411,7 @@ class UserServiceTest {
 			.division(3)
 			.name(name)
 			.tagLine("tagLine")
-			.status(Status.ONLINE).lp(3L)
+			.nowStatus(Status.ONLINE).lp(3L)
 			.build();
 	}
 


### PR DESCRIPTION
웹소켓 연결 시, 전에 사용자가 선택한 상태값으로 변경

## 변경점
### User엔티티 수정
 - 기존 state필드를 nowStatus로 수정
 - 사용자가 선택한 상태값인 selectedStatus 추가

### stompService.updateConnStatus() 수정
- isByUser 파리미터 추가
     true: 사용자가 직접 상태값을 변경할 경우
     false: 웹소켓 연결 상태에 의해 상태값을 변경할 경우
    (@kariskan  MemberController와 MemberControllerTest 코드 수정했습니다)

