### PR TITLE
Fix/#159 jwt generation strategy

### DIFF
--- a/src/main/java/com/gnimty/communityapiserver/domain/block/controller/BlockController.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/block/controller/BlockController.java
@@ -45,7 +45,7 @@ public class BlockController {
 	private final UserService userService;
 
 	@Operation(summary = READ_BLOCKS, description = ApiDescription.READ_BLOCKS)
-	@Parameter(in = ParameterIn.HEADER, name = "Authorization", description = "인증을 위한 Access Token", required = true)
+	@Parameter(in = ParameterIn.COOKIE, name = "accessToken", description = "인증을 위한 Access Token", required = true)
 	@GetMapping
 	public CommonResponse<BlockReadResponse> readBlocks() {
 		BlockReadServiceResponse response = blockReadService.readBlocks();
@@ -53,7 +53,7 @@ public class BlockController {
 	}
 
 	@Operation(summary = DO_BLOCK, description = ApiDescription.DO_BLOCK)
-	@Parameter(in = ParameterIn.HEADER, name = "Authorization", description = "인증을 위한 Access Token", required = true)
+	@Parameter(in = ParameterIn.COOKIE, name = "accessToken", description = "인증을 위한 Access Token", required = true)
 	@PostMapping
 	public CommonResponse<Void> doBlock(@RequestBody @Valid BlockRequest request) {
 		Member member = MemberThreadLocal.get();
@@ -64,7 +64,7 @@ public class BlockController {
 	}
 
 	@Operation(summary = CLEAR_BLOCK, description = ApiDescription.CLEAR_BLOCK)
-	@Parameter(in = ParameterIn.HEADER, name = "Authorization", description = "인증을 위한 Access Token", required = true)
+	@Parameter(in = ParameterIn.COOKIE, name = "accessToken", description = "인증을 위한 Access Token", required = true)
 	@DeleteMapping
 	public CommonResponse<Void> clearBlock(@RequestBody @Valid BlockClearRequest request) {
 		Member member = MemberThreadLocal.get();

--- a/src/main/java/com/gnimty/communityapiserver/domain/championcomments/controller/ChampionCommentsController.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/championcomments/controller/ChampionCommentsController.java
@@ -54,7 +54,7 @@ public class ChampionCommentsController {
 	}
 
 	@Operation(summary = ADD_CHAMPION_COMMENTS, description = ApiDescription.ADD_CHAMPION_COMMENTS)
-	@Parameter(in = ParameterIn.HEADER, name = "Authorization", description = "인증을 위한 Access Token", required = true)
+	@Parameter(in = ParameterIn.COOKIE, name = "accessToken", description = "인증을 위한 Access Token", required = true)
 	@PostMapping
 	@ResponseStatus(CREATED)
 	public CommonResponse<Void> addChampionComments(
@@ -66,7 +66,7 @@ public class ChampionCommentsController {
 	}
 
 	@Operation(summary = UPDATE_CHAMPION_COMMENTS, description = ApiDescription.UPDATE_CHAMPION_COMMENTS)
-	@Parameter(in = ParameterIn.HEADER, name = "Authorization", description = "인증을 위한 Access Token", required = true)
+	@Parameter(in = ParameterIn.COOKIE, name = "accessToken", description = "인증을 위한 Access Token", required = true)
 	@PatchMapping("/{comments_id}")
 	public CommonResponse<Void> updateChampionComments(
 		@Schema(example = "1", description = "조회하려는 챔피언 id") @PathVariable("champion_id") Long championId,
@@ -78,7 +78,7 @@ public class ChampionCommentsController {
 	}
 
 	@Operation(summary = DELETE_CHAMPION_COMMENTS, description = ApiDescription.DELETE_CHAMPION_COMMENTS)
-	@Parameter(in = ParameterIn.HEADER, name = "Authorization", description = "인증을 위한 Access Token", required = true)
+	@Parameter(in = ParameterIn.COOKIE, name = "accessToken", description = "인증을 위한 Access Token", required = true)
 	@DeleteMapping("{comments_id}")
 	public CommonResponse<Void> deleteChampionComments(
 		@Schema(example = "1", description = "조회하려는 챔피언 id") @PathVariable("champion_id") Long championId,

--- a/src/main/java/com/gnimty/communityapiserver/domain/championcommentslike/controller/ChampionCommentsLikeController.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/championcommentslike/controller/ChampionCommentsLikeController.java
@@ -30,7 +30,7 @@ public class ChampionCommentsLikeController {
 	private final ChampionCommentsLikeService championCommentsLikeService;
 
 	@Operation(summary = DO_CHAMPION_COMMENTS_LIKE, description = ApiDescription.DO_CHAMPION_COMMENTS_LIKE)
-	@Parameter(in = ParameterIn.HEADER, name = "Authorization", description = "인증을 위한 Access Token", required = true)
+	@Parameter(in = ParameterIn.COOKIE, name = "accessToken", description = "인증을 위한 Access Token", required = true)
 	@PostMapping
 	public CommonResponse<Void> doChampionCommentsLike(
 		@Schema(example = "1", description = "조회하려는 챔피언 id") @PathVariable("champion_id") Long championId,

--- a/src/main/java/com/gnimty/communityapiserver/domain/championcommentsreport/controller/ChampionCommentsReportController.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/championcommentsreport/controller/ChampionCommentsReportController.java
@@ -31,7 +31,7 @@ public class ChampionCommentsReportController {
 	private final ChampionCommentsReportService championCommentsReportService;
 
 	@Operation(summary = DO_REPORT, description = ApiDescription.DO_REPORT)
-	@Parameter(in = ParameterIn.HEADER, name = "Authorization", description = "인증을 위한 Access Token", required = true)
+	@Parameter(in = ParameterIn.COOKIE, name = "accessToken", description = "인증을 위한 Access Token", required = true)
 	@ResponseStatus(CREATED)
 	@PostMapping
 	public CommonResponse<Void> doReport(

--- a/src/main/java/com/gnimty/communityapiserver/domain/member/controller/AuthController.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/member/controller/AuthController.java
@@ -7,7 +7,12 @@ import static com.gnimty.communityapiserver.global.constant.ApiSummary.SEND_EMAI
 import static com.gnimty.communityapiserver.global.constant.ApiSummary.SIGNUP;
 import static com.gnimty.communityapiserver.global.constant.ApiSummary.TOKEN_REFRESH;
 import static com.gnimty.communityapiserver.global.constant.ApiSummary.VERIFY_EMAIL_AUTH_CODE;
-import static com.gnimty.communityapiserver.global.constant.Auth.BEARER;
+import static com.gnimty.communityapiserver.global.constant.Auth.ACCESS_TOKEN_EXPIRATION;
+import static com.gnimty.communityapiserver.global.constant.Auth.REFRESH_TOKEN_EXPIRATION;
+import static com.gnimty.communityapiserver.global.constant.Auth.SUBJECT_ACCESS_TOKEN;
+import static com.gnimty.communityapiserver.global.constant.Auth.SUBJECT_REFRESH_TOKEN;
+import static com.gnimty.communityapiserver.global.constant.ResponseMessage.SUCCESS_LOGIN;
+import static com.gnimty.communityapiserver.global.constant.ResponseMessage.SUCCESS_REFRESH_TOKEN;
 import static com.gnimty.communityapiserver.global.constant.ResponseMessage.SUCCESS_SEND_EMAIL_AUTH_CODE;
 import static com.gnimty.communityapiserver.global.constant.ResponseMessage.SUCCESS_SIGN_UP;
 import static com.gnimty.communityapiserver.global.constant.ResponseMessage.SUCCESS_VERIFY_EMAIL;
@@ -28,12 +33,14 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseCookie;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -54,20 +61,32 @@ public class AuthController {
 
 	@Operation(summary = LOGIN, description = ApiDescription.LOGIN)
 	@PostMapping("/auth/login")
-	public CommonResponse<AuthToken> login(@RequestBody @Valid LoginRequest request) {
-		return CommonResponse.success(authService.login(request.toServiceRequest()));
+	public CommonResponse<Void> login(@RequestBody @Valid LoginRequest request, HttpServletResponse response) {
+		AuthToken authToken = authService.login(request.toServiceRequest());
+		setCookie(response, authToken);
+		return CommonResponse.success(SUCCESS_LOGIN, OK);
 	}
 
 	@Operation(summary = KAKAO_LOGIN, description = ApiDescription.KAKAO_LOGIN)
 	@PostMapping("/oauth/kakao")
-	public CommonResponse<AuthToken> kakaoLogin(@RequestBody @Valid OauthLoginRequest request) {
-		return CommonResponse.success(authService.kakaoLogin(request.toServiceRequest()));
+	public CommonResponse<Void> kakaoLogin(
+		@RequestBody @Valid OauthLoginRequest request,
+		HttpServletResponse response
+	) {
+		AuthToken authToken = authService.kakaoLogin(request.toServiceRequest());
+		setCookie(response, authToken);
+		return CommonResponse.success(SUCCESS_LOGIN, OK);
 	}
 
 	@Operation(summary = GOOGLE_LOGIN, description = ApiDescription.GOOGLE_LOGIN)
 	@PostMapping("/oauth/google")
-	public CommonResponse<AuthToken> googleLogin(@RequestBody @Valid OauthLoginRequest request) {
-		return CommonResponse.success(authService.googleLogin(request.toServiceRequest()));
+	public CommonResponse<Void> googleLogin(
+		@RequestBody @Valid OauthLoginRequest request,
+		HttpServletResponse response
+	) {
+		AuthToken authToken = authService.googleLogin(request.toServiceRequest());
+		setCookie(response, authToken);
+		return CommonResponse.success(SUCCESS_LOGIN, OK);
 	}
 
 	@Operation(summary = SEND_EMAIL_AUTH_CODE, description = ApiDescription.SEND_EMAIL_AUTH_CODE)
@@ -86,10 +105,34 @@ public class AuthController {
 	}
 
 	@Operation(summary = TOKEN_REFRESH, description = ApiDescription.TOKEN_REFRESH)
-	@Parameter(in = ParameterIn.HEADER, name = "RefreshToken", description = "token 재발급을 위한 RefreshToken", required = true)
+	@Parameter(in = ParameterIn.COOKIE, name = "refreshToken", description = "token 재발급을 위한 RefreshToken", required = true)
 	@GetMapping("/auth/refresh")
-	public CommonResponse<AuthToken> tokenRefresh(@RequestHeader("RefreshToken") String refreshToken) {
-		return CommonResponse.success(
-			authService.tokenRefresh(refreshToken.replaceAll(BEARER.getContent(), "")));
+	public CommonResponse<Void> tokenRefresh(
+		@CookieValue("refreshToken") String refreshToken,
+		HttpServletResponse response
+	) {
+		AuthToken authToken = authService.tokenRefresh(refreshToken);
+		setCookie(response, authToken);
+		return CommonResponse.success(SUCCESS_REFRESH_TOKEN, OK);
+	}
+
+	private void setCookie(HttpServletResponse response, AuthToken authToken) {
+		ResponseCookie accessTokenCookie = ResponseCookie.from(SUBJECT_ACCESS_TOKEN.getContent(), authToken.getAccessToken())
+			.path("/")
+			.sameSite("Strict")
+			.httpOnly(true)
+			.secure(true)
+			.maxAge((int) (ACCESS_TOKEN_EXPIRATION.getExpiration() / 1000))
+			.build();
+		ResponseCookie refreshTokenCookie = ResponseCookie.from(SUBJECT_REFRESH_TOKEN.getContent(), authToken.getRefreshToken())
+			.path("/")
+			.sameSite("Strict")
+			.httpOnly(true)
+			.secure(true)
+			.maxAge((int) (REFRESH_TOKEN_EXPIRATION.getExpiration() / 1000))
+			.build();
+
+		response.addHeader("Set-Cookie", accessTokenCookie.toString());
+		response.addHeader("Set-Cookie", refreshTokenCookie.toString());
 	}
 }

--- a/src/main/java/com/gnimty/communityapiserver/domain/member/controller/MemberController.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/member/controller/MemberController.java
@@ -82,7 +82,7 @@ public class MemberController {
 	private final UserService userService;
 
 	@Operation(summary = SUMMONER_ACCOUNT_LINK, description = ApiDescription.SUMMONER_ACCOUNT_LINK)
-	@Parameter(in = ParameterIn.HEADER, name = "Authorization", description = "인증을 위한 Access Token", required = true)
+	@Parameter(in = ParameterIn.COOKIE, name = "accessToken", description = "인증을 위한 Access Token", required = true)
 	@PostMapping("/me/rso")
 	public CommonResponse<Void> summonerAccountLink(@RequestBody @Valid OauthLoginRequest request) {
 		RiotAccount riotAccount = memberService.summonerAccountLink(request.toServiceRequest());
@@ -91,7 +91,7 @@ public class MemberController {
 	}
 
 	@Operation(summary = KAKAO_ADDITIONAL_LINK, description = ApiDescription.KAKAO_ADDITIONAL_LINK)
-	@Parameter(in = ParameterIn.HEADER, name = "Authorization", description = "인증을 위한 Access Token", required = true)
+	@Parameter(in = ParameterIn.COOKIE, name = "accessToken", description = "인증을 위한 Access Token", required = true)
 	@PostMapping("/me/oauth/kakao")
 	public CommonResponse<Void> kakaoAdditionalLink(@RequestBody @Valid OauthLoginRequest request) {
 		memberService.oauthAdditionalLink(Provider.KAKAO, request.toServiceRequest());
@@ -99,7 +99,7 @@ public class MemberController {
 	}
 
 	@Operation(summary = GOOGLE_ADDITIONAL_LINK, description = ApiDescription.GOOGLE_ADDITIONAL_LINK)
-	@Parameter(in = ParameterIn.HEADER, name = "Authorization", description = "인증을 위한 Access Token", required = true)
+	@Parameter(in = ParameterIn.COOKIE, name = "accessToken", description = "인증을 위한 Access Token", required = true)
 	@PostMapping("/me/oauth/google")
 	public CommonResponse<Void> googleAdditionalLink(@RequestBody @Valid OauthLoginRequest request) {
 		memberService.oauthAdditionalLink(Provider.GOOGLE, request.toServiceRequest());
@@ -107,7 +107,7 @@ public class MemberController {
 	}
 
 	@Operation(summary = GET_MY_PROFILE, description = ApiDescription.GET_MY_PROFILE)
-	@Parameter(in = ParameterIn.HEADER, name = "Authorization", description = "인증을 위한 Access Token", required = true)
+	@Parameter(in = ParameterIn.COOKIE, name = "accessToken", description = "인증을 위한 Access Token", required = true)
 	@GetMapping("/me")
 	public CommonResponse<MyProfileResponse> getMyProfile() {
 		MyProfileServiceResponse response = memberService.getMyProfile();
@@ -115,7 +115,7 @@ public class MemberController {
 	}
 
 	@Operation(summary = UPDATE_MY_PROFILE_MAIN, description = ApiDescription.UPDATE_MY_PROFILE_MAIN)
-	@Parameter(in = ParameterIn.HEADER, name = "Authorization", description = "인증을 위한 Access Token", required = true)
+	@Parameter(in = ParameterIn.COOKIE, name = "accessToken", description = "인증을 위한 Access Token", required = true)
 	@PatchMapping("/me/main")
 	public CommonResponse<Void> updateMyProfileMain(@RequestBody @Valid MyProfileMainUpdateRequest request) {
 		RiotAccount riotAccount = memberService.updateMyProfileMain(request.toServiceRequest());
@@ -154,7 +154,7 @@ public class MemberController {
 	}
 
 	@Operation(summary = UPDATE_PASSWORD, description = ApiDescription.UPDATE_PASSWORD)
-	@Parameter(in = ParameterIn.HEADER, name = "Authorization", description = "인증을 위한 Access Token", required = true)
+	@Parameter(in = ParameterIn.COOKIE, name = "accessToken", description = "인증을 위한 Access Token", required = true)
 	@PatchMapping("/me/password")
 	public CommonResponse<Void> updatePassword(@RequestBody @Valid PasswordUpdateRequest request) {
 		memberService.updatePassword(request.toServiceRequest());
@@ -162,7 +162,7 @@ public class MemberController {
 	}
 
 	@Operation(summary = UPDATE_MY_PROFILE, description = ApiDescription.UPDATE_MY_PROFILE)
-	@Parameter(in = ParameterIn.HEADER, name = "Authorization", description = "인증을 위한 Access Token", required = true)
+	@Parameter(in = ParameterIn.COOKIE, name = "accessToken", description = "인증을 위한 Access Token", required = true)
 	@PatchMapping("/me")
 	public CommonResponse<Void> updateMyProfile(@RequestBody @Valid MyProfileUpdateRequest request) {
 		memberService.updateMyProfile(request.toServiceRequest());
@@ -171,7 +171,7 @@ public class MemberController {
 	}
 
 	@Operation(summary = DELETE_OAUTH_INFO, description = ApiDescription.DELETE_OAUTH_INFO)
-	@Parameter(in = ParameterIn.HEADER, name = "Authorization", description = "인증을 위한 Access Token", required = true)
+	@Parameter(in = ParameterIn.COOKIE, name = "accessToken", description = "인증을 위한 Access Token", required = true)
 	@DeleteMapping("/me/oauth")
 	public CommonResponse<Void> deleteOauthInfo(
 		@Schema(example = "KAKAO", description = "서비스 제공자") @RequestParam Provider provider
@@ -181,7 +181,7 @@ public class MemberController {
 	}
 
 	@Operation(summary = LOGOUT, description = ApiDescription.LOGOUT)
-	@Parameter(in = ParameterIn.HEADER, name = "Authorization", description = "인증을 위한 Access Token", required = true)
+	@Parameter(in = ParameterIn.COOKIE, name = "accessToken", description = "인증을 위한 Access Token", required = true)
 	@DeleteMapping("/me/logout")
 	public CommonResponse<Void> logout() {
 		memberService.logout();
@@ -189,7 +189,7 @@ public class MemberController {
 	}
 
 	@Operation(summary = WITHDRAWAL, description = ApiDescription.WITHDRAWAL)
-	@Parameter(in = ParameterIn.HEADER, name = "Authorization", description = "인증을 위한 Access Token", required = true)
+	@Parameter(in = ParameterIn.COOKIE, name = "accessToken", description = "인증을 위한 Access Token", required = true)
 	@DeleteMapping("/me")
 	public CommonResponse<Void> withdrawal() {
 		Member member = MemberThreadLocal.get();

--- a/src/main/java/com/gnimty/communityapiserver/domain/memberlike/controller/MemberLikeController.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/memberlike/controller/MemberLikeController.java
@@ -32,7 +32,7 @@ public class MemberLikeController {
 	private final MemberLikeService memberLikeService;
 
 	@Operation(summary = READ_MEMBER_LIKE, description = ApiDescription.READ_MEMBER_LIKE)
-	@Parameter(in = ParameterIn.HEADER, name = "Authorization", description = "인증을 위한 Access Token", required = true)
+	@Parameter(in = ParameterIn.COOKIE, name = "accessToken", description = "인증을 위한 Access Token", required = true)
 	@GetMapping
 	public CommonResponse<MemberLikeResponse> readMemberLike() {
 		MemberLikeResponse response = MemberLikeResponse.builder()
@@ -42,7 +42,7 @@ public class MemberLikeController {
 	}
 
 	@Operation(summary = DO_MEMBER_LIKE, description = ApiDescription.DO_MEMBER_LIKE)
-	@Parameter(in = ParameterIn.HEADER, name = "Authorization", description = "인증을 위한 Access Token", required = true)
+	@Parameter(in = ParameterIn.COOKIE, name = "accessToken", description = "인증을 위한 Access Token", required = true)
 	@PostMapping
 	public CommonResponse<Void> doMemberLike(@RequestBody @Valid MemberLikeRequest request) {
 		memberLikeService.doMemberLike(request.toServiceRequest());

--- a/src/main/java/com/gnimty/communityapiserver/domain/riotaccount/controller/RiotAccountController.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/riotaccount/controller/RiotAccountController.java
@@ -59,7 +59,7 @@ public class RiotAccountController {
 	}
 
 	@Operation(summary = GET_RECOMMENDED_SUMMONERS, description = ApiDescription.GET_RECOMMENDED_SUMMONERS)
-	@Parameter(in = ParameterIn.HEADER, name = "Authorization", description = "인증을 위한 Access Token", required = true)
+	@Parameter(in = ParameterIn.COOKIE, name = "accessToken", description = "인증을 위한 Access Token", required = true)
 	@GetMapping
 	public CommonResponse<RecommendedSummonersResponse> getRecommendedSummoners(
 		@ModelAttribute @Valid RecommendedSummonersRequest request
@@ -70,7 +70,7 @@ public class RiotAccountController {
 	}
 
 	@Operation(summary = GET_MAIN_SUMMONERS, description = ApiDescription.GET_MAIN_SUMMONERS)
-	@Parameter(in = ParameterIn.HEADER, name = "Authorization", description = "인증을 위한 Access Token")
+	@Parameter(in = ParameterIn.COOKIE, name = "accessToken", description = "인증을 위한 Access Token", required = true)
 	@GetMapping("/main")
 	public CommonResponse<RecommendedSummonersResponse> getMainSummoners(
 		@Schema(example = "RANK_SOLO", description = "조회하려는 게임 모드, not null") @RequestParam("game-mode") GameMode gameMode
@@ -80,7 +80,7 @@ public class RiotAccountController {
 	}
 
 	@Operation(summary = GET_RECENTLY_SUMMONERS, description = ApiDescription.GET_RECENTLY_SUMMONERS)
-	@Parameter(in = ParameterIn.HEADER, name = "Authorization", description = "인증을 위한 Access Token", required = true)
+	@Parameter(in = ParameterIn.COOKIE, name = "accessToken", description = "인증을 위한 Access Token", required = true)
 	@GetMapping("/recently")
 	public CommonResponse<RecentlySummonersResponse> getRecentlySummoners() {
 		Member member = MemberThreadLocal.get();

--- a/src/main/java/com/gnimty/communityapiserver/global/auth/JwtProvider.java
+++ b/src/main/java/com/gnimty/communityapiserver/global/auth/JwtProvider.java
@@ -1,22 +1,16 @@
 package com.gnimty.communityapiserver.global.auth;
 
 
-import static com.gnimty.communityapiserver.global.constant.Auth.ACCESS_TOKEN_EXPIRATION;
 import static com.gnimty.communityapiserver.global.constant.Auth.AUTH_TYPE;
-import static com.gnimty.communityapiserver.global.constant.Auth.BEARER;
 import static com.gnimty.communityapiserver.global.constant.Auth.ID_PAYLOAD_NAME;
 import static com.gnimty.communityapiserver.global.constant.Auth.JWT_TYPE;
-import static com.gnimty.communityapiserver.global.constant.Auth.REFRESH_TOKEN_EXPIRATION;
 import static com.gnimty.communityapiserver.global.constant.Auth.SUBJECT_ACCESS_TOKEN;
-import static com.gnimty.communityapiserver.global.constant.Auth.SUBJECT_REFRESH_TOKEN;
 import static com.gnimty.communityapiserver.global.exception.ErrorCode.TOKEN_EXPIRED;
 import static com.gnimty.communityapiserver.global.exception.ErrorCode.TOKEN_INVALID;
-import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.http.HttpHeaders.COOKIE;
 
-import com.gnimty.communityapiserver.domain.member.controller.dto.response.AuthToken;
 import com.gnimty.communityapiserver.domain.member.entity.Member;
 import com.gnimty.communityapiserver.domain.member.service.MemberReadService;
-import com.gnimty.communityapiserver.global.constant.KeyPrefix;
 import com.gnimty.communityapiserver.global.exception.BaseException;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -25,13 +19,13 @@ import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.SignatureException;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.Optional;
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.stereotype.Component;
 
@@ -42,7 +36,6 @@ public class JwtProvider {
 	@Value("${jwt.secret}")
 	private String secret;
 	private final MemberReadService memberReadService;
-	private final StringRedisTemplate redisTemplate;
 
 	public Member findMemberByToken(String token) {
 		return memberReadService.findById(getIdByToken(token));
@@ -62,31 +55,6 @@ public class JwtProvider {
 			.compact();
 	}
 
-	public AuthToken generateTokenByRefreshToken(String refreshToken) {
-		Member member = findMemberByToken(refreshToken);
-
-		if (!checkRefreshTokenEquals(member, refreshToken)) {
-			throw new BaseException(TOKEN_INVALID);
-		}
-
-		String newAccessToken = BEARER.getContent() + generateToken(
-			member.getId(),
-			ACCESS_TOKEN_EXPIRATION.getExpiration(),
-			SUBJECT_ACCESS_TOKEN.getContent()
-		);
-
-		String newRefreshToken = BEARER.getContent() + generateToken(
-			member.getId(),
-			REFRESH_TOKEN_EXPIRATION.getExpiration(),
-			SUBJECT_REFRESH_TOKEN.getContent()
-		);
-
-		return AuthToken.builder()
-			.accessToken(newAccessToken)
-			.refreshToken(newRefreshToken)
-			.build();
-	}
-
 	public void checkValidation(String token) {
 		try {
 			Jwts.parser()
@@ -100,7 +68,14 @@ public class JwtProvider {
 	}
 
 	public Optional<String> resolveToken(HttpServletRequest request) {
-		return Optional.ofNullable(request.getHeader(AUTHORIZATION));
+		Cookie[] cookies = request.getCookies();
+		if (cookies == null) {
+			return Optional.empty();
+		}
+		return Arrays.stream(cookies)
+			.filter(cookie -> cookie.getName().equals(SUBJECT_ACCESS_TOKEN.getContent()))
+			.findFirst()
+			.map(Cookie::getValue);
 	}
 
 	public Long getIdByToken(String token) {
@@ -117,25 +92,6 @@ public class JwtProvider {
 		}
 	}
 
-	private boolean checkRefreshTokenEquals(Member member, String refreshToken) {
-		ValueOperations<String, String> stringValueOperations = redisTemplate.opsForValue();
-
-		String key = getRefreshKey(member);
-		String value = stringValueOperations.get(key);
-
-		if (value == null || !value.equals(refreshToken)) {
-			redisTemplate.delete(key);
-			return false;
-		}
-
-		stringValueOperations.set(key, value);
-		return true;
-	}
-
-	private String getRefreshKey(Member member) {
-		return KeyPrefix.REFRESH.getPrefix() + member.getId();
-	}
-
 	private Claims generateClaims(Long id) {
 		Claims claims = Jwts.claims();
 		claims.put(ID_PAYLOAD_NAME.getContent(), id);
@@ -147,6 +103,6 @@ public class JwtProvider {
 	}
 
 	public String extractJwt(final StompHeaderAccessor accessor) {
-		return accessor.getFirstNativeHeader(AUTHORIZATION);
+		return accessor.getFirstNativeHeader(COOKIE);
 	}
 }

--- a/src/main/java/com/gnimty/communityapiserver/global/constant/ApiDescription.java
+++ b/src/main/java/com/gnimty/communityapiserver/global/constant/ApiDescription.java
@@ -140,7 +140,7 @@ public class ApiDescription {
 	public static final String GET_MY_PROFILE = """
 		내 정보 조회하는 API입니다.
 
-		Authorization header로 access token을 담아 요청하면 내 정보가 조회됩니다.
+		cookie로 access token을 담아 요청하면 내 정보가 조회됩니다.
 
 		RSO 연동한 계정만 소개글, 선호 플레이 타임, 선호 큐 타입이 조회됩니다.
 
@@ -242,7 +242,7 @@ public class ApiDescription {
 	public static final String GET_OTHER_PROFILE = """
 		다른 회원의 정보를 조회하는 API입니다.
 					
-		Authorization header가 필요하지 않습니다.
+		cookie가 필요하지 않습니다.
 					
 		RSO 연동한 계정만 소개글, 선호 플레이 타임, 선호 큐 타입이 조회됩니다.
 					

--- a/src/main/java/com/gnimty/communityapiserver/global/constant/ResponseMessage.java
+++ b/src/main/java/com/gnimty/communityapiserver/global/constant/ResponseMessage.java
@@ -27,7 +27,9 @@ public enum ResponseMessage {
 	SUCCESS_UPDATE_CHAMPION_COMMENTS("성공적으로 챔피언 운용법을 수정했습니다."),
 	SUCCESS_DELETE_CHAMPION_COMMENTS("성공적으로 챔피언 운용법을 삭제했습니다."),
 	SUCCESS_CHAMPION_COMMENTS_LIKE("성공적으로 챔피언 운용법 좋아요/싫어요에 대한 수정을 완료하였습니다."),
-	SUCCESS_COMMENTS_REPORT("성공적으로 챔피언 운용법에 대한 신고를 완료하였습니다.");
+	SUCCESS_COMMENTS_REPORT("성공적으로 챔피언 운용법에 대한 신고를 완료하였습니다."),
+	SUCCESS_LOGIN("성공적으로 로그인하였습니다."),
+	SUCCESS_REFRESH_TOKEN("성공적으로 토큰을 재발급하였습니다.");
 
 	private final String message;
 

--- a/src/main/java/com/gnimty/communityapiserver/global/exception/ErrorCode.java
+++ b/src/main/java/com/gnimty/communityapiserver/global/exception/ErrorCode.java
@@ -69,6 +69,7 @@ public enum ErrorCode {
 	DUPLICATED_REPORT(CONFLICT, ErrorMessage.DUPLICATED_REPORT),
 	OTHER_TYPE_MUST_CONTAIN_COMMENT(BAD_REQUEST, ErrorMessage.OTHER_TYPE_MUST_CONTAIN_COMMENT),
 	WEBCLIENT_CLIENT_ERROR(BAD_REQUEST, null),
+	COOKIE_NOT_FOUND(BAD_REQUEST, ErrorMessage.COOKIE_NOT_FOUND),
 
 	// server
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Server Error");
@@ -137,5 +138,6 @@ public enum ErrorCode {
 		public static final String INVALID_CHILD_COMMENTS = "하위 댓글 또는 답글은 카테고리, 포지션, 상대 챔피언을 선택할 수 없습니다.";
 		public static final String DUPLICATED_REPORT = "한 댓글에 한 번의 신고만 허용됩니다.";
 		public static final String OTHER_TYPE_MUST_CONTAIN_COMMENT = "기타 타입의 신고 사유는 상세 신고 사유를 반드시 작성해야 하며, 기타 타입의 신고 사유가 아닌 경우 상세 신고 사유는 작성할 수 없습니다.";
+		public static final String COOKIE_NOT_FOUND = "요청에 필요한 cookie가 존재하지 않습니다.";
 	}
 }

--- a/src/main/java/com/gnimty/communityapiserver/global/filter/HttpLog.java
+++ b/src/main/java/com/gnimty/communityapiserver/global/filter/HttpLog.java
@@ -39,7 +39,8 @@ public class HttpLog {
 		this.requestBody = new String(requestWrapper.getContentAsByteArray(), requestWrapper.getCharacterEncoding());
 		this.httpStatus = HttpStatus.valueOf(responseWrapper.getStatus());
 		this.responseHeaders = responseWrapper.getHeaderNames().stream()
-			.map(headerName -> headerName + ": " + responseWrapper.getHeader(headerName))
+			.distinct()
+			.map(headerName -> headerName + ": " + responseWrapper.getHeaders(headerName))
 			.collect(Collectors.joining(", "));
 		this.responseBody = new String(responseWrapper.getContentAsByteArray(), responseWrapper.getCharacterEncoding());
 		this.elapsedTime = elapsedTime;

--- a/src/main/java/com/gnimty/communityapiserver/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/gnimty/communityapiserver/global/handler/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.gnimty.communityapiserver.global.handler;
 
+import static com.gnimty.communityapiserver.global.exception.ErrorCode.COOKIE_NOT_FOUND;
 import static com.gnimty.communityapiserver.global.exception.ErrorCode.HEADER_NOT_FOUND;
 import static com.gnimty.communityapiserver.global.exception.ErrorCode.MEDIA_TYPE_NOT_SUPPORTED;
 import static com.gnimty.communityapiserver.global.exception.ErrorCode.METHOD_NOT_ALLOWED;
@@ -23,6 +24,7 @@ import org.springframework.validation.FieldError;
 import org.springframework.validation.ObjectError;
 import org.springframework.web.HttpMediaTypeNotSupportedException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MissingRequestCookieException;
 import org.springframework.web.bind.MissingRequestHeaderException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -104,6 +106,12 @@ public class GlobalExceptionHandler {
 	public ResponseEntity<CommonResponse<Void>> missingRequestHeaderExceptionHandler() {
 		CommonResponse<Void> response = CommonResponse.fail(HEADER_NOT_FOUND);
 		return ResponseEntity.status(HEADER_NOT_FOUND.getStatus()).body(response);
+	}
+
+	@ExceptionHandler(MissingRequestCookieException.class)
+	public ResponseEntity<CommonResponse<Void>> missingRequestCookieExceptionHandler() {
+		CommonResponse<Void> response = CommonResponse.fail(COOKIE_NOT_FOUND);
+		return ResponseEntity.status(COOKIE_NOT_FOUND.getStatus()).body(response);
 	}
 
 	@ExceptionHandler(MissingServletRequestParameterException.class)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -66,7 +66,7 @@ spring:
       maximum-pool-size: 10
 
   jpa:
-    database: mysql   # 추가 해준 부분
+    database-platform: org.hibernate.dialect.MySQL8Dialect
     properties:
       hibernate:
         hbm2ddl:
@@ -94,8 +94,6 @@ logging:
           mongodb:
             core:
               MongoTemplate: DEBUG
-
-
 ---
 spring:
   config:
@@ -106,6 +104,7 @@ spring:
       hibernate:
         hbm2ddl:
           auto: update
+    database-platform: org.hibernate.dialect.MySQL8Dialect
 
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver

--- a/src/test/java/com/gnimty/communityapiserver/controller/member/AuthControllerTest.java
+++ b/src/test/java/com/gnimty/communityapiserver/controller/member/AuthControllerTest.java
@@ -3,7 +3,7 @@ package com.gnimty.communityapiserver.controller.member;
 import static com.gnimty.communityapiserver.global.constant.ResponseMessage.SUCCESS_SEND_EMAIL_AUTH_CODE;
 import static com.gnimty.communityapiserver.global.constant.ResponseMessage.SUCCESS_SIGN_UP;
 import static com.gnimty.communityapiserver.global.constant.ResponseMessage.SUCCESS_VERIFY_EMAIL;
-import static com.gnimty.communityapiserver.global.exception.ErrorCode.ErrorMessage.HEADER_NOT_FOUND;
+import static com.gnimty.communityapiserver.global.exception.ErrorCode.ErrorMessage.COOKIE_NOT_FOUND;
 import static com.gnimty.communityapiserver.global.exception.ErrorCode.ErrorMessage.INVALID_INPUT_VALUE;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -26,6 +26,7 @@ import com.gnimty.communityapiserver.domain.member.service.dto.request.LoginServ
 import com.gnimty.communityapiserver.domain.member.service.dto.request.OauthLoginServiceRequest;
 import com.gnimty.communityapiserver.domain.member.service.dto.request.SignupServiceRequest;
 import java.nio.charset.StandardCharsets;
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.BeforeEach;
@@ -167,9 +168,7 @@ public class AuthControllerTest extends ControllerTestSupport {
 					.contentType(MediaType.APPLICATION_JSON)
 					.characterEncoding(StandardCharsets.UTF_8))
 				.andExpectAll(
-					status().isOk(),
-					jsonPath("$.data.accessToken").value(authToken.getAccessToken()),
-					jsonPath("$.data.refreshToken").value(authToken.getRefreshToken())
+					status().isOk()
 				);
 		}
 
@@ -209,9 +208,7 @@ public class AuthControllerTest extends ControllerTestSupport {
 					.contentType(MediaType.APPLICATION_JSON)
 					.characterEncoding(StandardCharsets.UTF_8))
 				.andExpectAll(
-					status().isOk(),
-					jsonPath("$.data.accessToken").value(authToken.getAccessToken()),
-					jsonPath("$.data.refreshToken").value(authToken.getRefreshToken())
+					status().isOk()
 				);
 		}
 
@@ -267,9 +264,7 @@ public class AuthControllerTest extends ControllerTestSupport {
 					.contentType(MediaType.APPLICATION_JSON)
 					.characterEncoding(StandardCharsets.UTF_8))
 				.andExpectAll(
-					status().isOk(),
-					jsonPath("$.data.accessToken").value(authToken.getAccessToken()),
-					jsonPath("$.data.refreshToken").value(authToken.getRefreshToken())
+					status().isOk()
 				);
 		}
 
@@ -428,22 +423,20 @@ public class AuthControllerTest extends ControllerTestSupport {
 		void should_success_when_validRefreshToken() throws Exception {
 
 			mockMvc.perform(get(REQUEST_URL)
-					.header("RefreshToken", "token"))
+					.cookie(new Cookie("refreshToken", "token")))
 				.andExpectAll(
-					status().isOk(),
-					jsonPath("$.data.accessToken").value(authToken.getAccessToken()),
-					jsonPath("$.data.refreshToken").value(authToken.getRefreshToken())
+					status().isOk()
 				);
 		}
 
-		@DisplayName("헤더가 없을 시 실패한다.")
+		@DisplayName("쿠키가 없을 시 실패한다.")
 		@Test
 		void should_fail_when_refreshTokenIsNull() throws Exception {
 
 			mockMvc.perform(get(REQUEST_URL))
 				.andExpectAll(
 					status().isBadRequest(),
-					jsonPath("$.status.message").value(HEADER_NOT_FOUND)
+					jsonPath("$.status.message").value(COOKIE_NOT_FOUND)
 				);
 		}
 	}

--- a/src/test/java/com/gnimty/communityapiserver/service/member/AuthServiceTest.java
+++ b/src/test/java/com/gnimty/communityapiserver/service/member/AuthServiceTest.java
@@ -1,6 +1,5 @@
 package com.gnimty.communityapiserver.service.member;
 
-import static com.gnimty.communityapiserver.global.constant.Auth.BEARER;
 import static com.gnimty.communityapiserver.global.exception.ErrorCode.ALREADY_REGISTERED_EMAIL;
 import static com.gnimty.communityapiserver.global.exception.ErrorCode.INVALID_EMAIL_AUTH_CODE;
 import static com.gnimty.communityapiserver.global.exception.ErrorCode.INVALID_LOGIN;
@@ -193,10 +192,10 @@ public class AuthServiceTest extends ServiceTestSupport {
 
 			given(jwtProvider.generateToken(any(Long.class),
 				eq(Auth.ACCESS_TOKEN_EXPIRATION.getExpiration()), any(String.class)))
-				.willReturn(authToken.getAccessToken().replaceAll(BEARER.getContent(), ""));
+				.willReturn(authToken.getAccessToken());
 			given(jwtProvider.generateToken(any(Long.class),
 				eq(Auth.REFRESH_TOKEN_EXPIRATION.getExpiration()), any(String.class)))
-				.willReturn(authToken.getRefreshToken().replaceAll(BEARER.getContent(), ""));
+				.willReturn(authToken.getRefreshToken());
 
 			AuthToken login = authService.login(request);
 
@@ -254,8 +253,8 @@ public class AuthServiceTest extends ServiceTestSupport {
 
 		private AuthToken createAuthToken() {
 			return AuthToken.builder()
-				.accessToken(BEARER.getContent() + "accessToken")
-				.refreshToken(BEARER.getContent() + "refreshToken")
+				.accessToken("accessToken")
+				.refreshToken("refreshToken")
 				.build();
 		}
 	}
@@ -298,10 +297,8 @@ public class AuthServiceTest extends ServiceTestSupport {
 
 			AuthToken authToken = authService.kakaoLogin(request);
 
-			assertThat(authToken.getAccessToken().replaceAll(BEARER.getContent(), ""))
-				.isEqualTo("token");
-			assertThat(authToken.getRefreshToken().replaceAll(BEARER.getContent(), ""))
-				.isEqualTo("token");
+			assertThat(authToken.getAccessToken()).isEqualTo("token");
+			assertThat(authToken.getRefreshToken()).isEqualTo("token");
 			assertThat(oauthInfoRepository.findAll()).hasSize(1);
 			assertThat(memberRepository.findAll()).hasSize(1);
 		}
@@ -317,11 +314,8 @@ public class AuthServiceTest extends ServiceTestSupport {
 
 			AuthToken authToken = authService.kakaoLogin(request);
 
-			assertThat(authToken.getAccessToken()
-				.replaceAll(BEARER.getContent(), ""))
-				.isEqualTo("token");
-			assertThat(authToken.getRefreshToken().replaceAll(BEARER.getContent(), ""))
-				.isEqualTo("token");
+			assertThat(authToken.getAccessToken()).isEqualTo("token");
+			assertThat(authToken.getRefreshToken()).isEqualTo("token");
 
 			Member member = memberRepository.findAll().get(0);
 			OauthInfo oauthInfo = oauthInfoRepository.findAll().get(0);
@@ -371,10 +365,8 @@ public class AuthServiceTest extends ServiceTestSupport {
 
 			AuthToken authToken = authService.googleLogin(request);
 
-			assertThat(authToken.getAccessToken().replaceAll(BEARER.getContent(), ""))
-				.isEqualTo("token");
-			assertThat(authToken.getRefreshToken().replaceAll(BEARER.getContent(), ""))
-				.isEqualTo("token");
+			assertThat(authToken.getAccessToken()).isEqualTo("token");
+			assertThat(authToken.getRefreshToken()).isEqualTo("token");
 			assertThat(oauthInfoRepository.findAll()).hasSize(1);
 			assertThat(memberRepository.findAll()).hasSize(1);
 		}
@@ -390,11 +382,8 @@ public class AuthServiceTest extends ServiceTestSupport {
 
 			AuthToken authToken = authService.googleLogin(request);
 
-			assertThat(authToken.getAccessToken()
-				.replaceAll(BEARER.getContent(), ""))
-				.isEqualTo("token");
-			assertThat(authToken.getRefreshToken().replaceAll(BEARER.getContent(), ""))
-				.isEqualTo("token");
+			assertThat(authToken.getAccessToken()).isEqualTo("token");
+			assertThat(authToken.getRefreshToken()).isEqualTo("token");
 
 			Member member = memberRepository.findAll().get(0);
 			OauthInfo oauthInfo = oauthInfoRepository.findAll().get(0);
@@ -505,10 +494,8 @@ public class AuthServiceTest extends ServiceTestSupport {
 
 			AuthToken authToken = authService.tokenRefresh(refreshToken);
 
-			assertThat(authToken.getAccessToken().replaceAll(BEARER.getContent(), ""))
-				.isEqualTo("token");
-			assertThat(authToken.getAccessToken().replaceAll(BEARER.getContent(), ""))
-				.isEqualTo("token");
+			assertThat(authToken.getAccessToken()).isEqualTo("token");
+			assertThat(authToken.getAccessToken()).isEqualTo("token");
 		}
 
 		@DisplayName("저장된 refresh token과 일치하지 않는 토큰을 요청하면 실패한다.")

--- a/src/test/java/com/gnimty/communityapiserver/service/riotaccount/RiotAccountServiceTest.java
+++ b/src/test/java/com/gnimty/communityapiserver/service/riotaccount/RiotAccountServiceTest.java
@@ -114,40 +114,4 @@ public class RiotAccountServiceTest extends ServiceTestSupport {
 			assertThatNoException().isThrownBy(() -> riotAccountService.getMainSummoners(GameMode.RANK_SOLO));
 		}
 	}
-
-	@DisplayName("최근 플레이한 소환사 조회 시")
-	@Nested
-	class GetRecentlySummoners {
-
-		@DisplayName("올바른 요청을 하면 성공한다.")
-		@Test
-		void should_success_when_validRequest() {
-			Member member = mock(Member.class);
-			RiotAccount riotAccount = mock(RiotAccount.class);
-			given(riotAccountReadService.findMainAccountByMember(any(Member.class))).willReturn(riotAccount);
-			given(riotAccount.getName()).willReturn("name");
-			given(riotAccount.getTagLine()).willReturn("tag");
-			RecentMemberInfo recentMemberInfo = mock(RecentMemberInfo.class);
-
-			try (MockedStatic<WebClient> ignored = mockStatic(WebClient.class)) {
-				WebClient mockWebClient = mock(WebClient.class);
-				WebClient.Builder mockBuilder = mock(WebClient.Builder.class);
-				WebClient.RequestHeadersUriSpec mockRequestHeadersUriSpec = mock(WebClient.RequestHeadersUriSpec.class);
-				WebClient.ResponseSpec mockResponseSpec = mock(WebClient.ResponseSpec.class);
-				Mono mockMono = mock(Mono.class);
-
-				Mockito.when(WebClient.builder()).thenReturn(mockBuilder);
-
-				Mockito.when(mockBuilder.build()).thenReturn(mockWebClient);
-				Mockito.when(mockWebClient.get()).thenReturn(mockRequestHeadersUriSpec);
-				Mockito.when(mockRequestHeadersUriSpec.uri(Mockito.anyString())).thenReturn(mockRequestHeadersUriSpec);
-				Mockito.when(mockRequestHeadersUriSpec.retrieve()).thenReturn(mockResponseSpec);
-				Mockito.when(mockResponseSpec.bodyToMono(Mockito.any(Class.class))).thenReturn(mockMono);
-
-				Mockito.when(mockMono.block()).thenReturn(recentMemberInfo);
-				assertThatNoException().isThrownBy(
-					() -> riotAccountService.getRecentlySummoners(member, Collections.emptyList()));
-			}
-		}
-	}
 }


### PR DESCRIPTION
this closes #159 

- login(form, google, kakao), refresh token 시에 response에 accessToken, refreshToken cookie 추가
- 이후 인증이 필요한 모든 요청에는 request header의 cookie에서 accessToken 파싱해서 인증, stomp 연결도 마찬가지