### PR TITLE
Enhance/#161 채팅 로깅 작업, 세션 관리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
     implementation 'org.webjars:stomp-websocket:2.3.3-1'
-    implementation group: 'joda-time', name: 'joda-time', version: '2.3'
 
     //cache
     implementation 'org.springframework.boot:spring-boot-starter-cache'

--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
     implementation 'org.webjars:stomp-websocket:2.3.3-1'
+    implementation group: 'joda-time', name: 'joda-time', version: '2.3'
 
     //cache
     implementation 'org.springframework.boot:spring-boot-starter-cache'

--- a/src/main/java/com/gnimty/communityapiserver/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/chat/controller/ChatController.java
@@ -111,7 +111,7 @@ public class ChatController {
 	public void onClientConnect(SessionConnectedEvent event) {
 		String sessionId = String.valueOf(event.getMessage().getHeaders().get("simpSessionId"));
 		User user = getUserBySessionId(sessionId);
-		log.info("[Connect] userId: {}", user.getActualUserId());
+		log.info("[Connect] userId: {} ", user.getActualUserId());
 		if (!isMultipleUser(user.getActualUserId())) {
 			stompService.updateConnStatus(user, user.getSelectedStatus(), false);
 			memberService.updateStatus(user.getSelectedStatus(), user.getActualUserId());

--- a/src/main/java/com/gnimty/communityapiserver/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/chat/controller/ChatController.java
@@ -138,7 +138,6 @@ public class ChatController {
 
 	private boolean isMultipleUser(Long memberId) {
 		int cnt = webSocketSessionManager.getSessionCountByMemberId(memberId);
-		log.info("isMultipleUser.cnt: {}", cnt);
 		return webSocketSessionManager.getSessionCountByMemberId(memberId) > 1;
 	}
 

--- a/src/main/java/com/gnimty/communityapiserver/global/config/StompConfiguration.java
+++ b/src/main/java/com/gnimty/communityapiserver/global/config/StompConfiguration.java
@@ -2,10 +2,13 @@ package com.gnimty.communityapiserver.global.config;
 
 import com.gnimty.communityapiserver.global.handler.StompExceptionHandler;
 import com.gnimty.communityapiserver.global.handler.StompHandler;
+import javax.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.WebSocketMessageBrokerStats;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
@@ -22,8 +25,7 @@ public class StompConfiguration implements WebSocketMessageBrokerConfigurer {
 	public void configureMessageBroker(MessageBrokerRegistry registry) {
 
 		registry.enableSimpleBroker("/sub"); //클라이언트로 메세지를 응답 해 줄 때 prefix 정의 - 클라이언트가 메세지를 받을 때
-		registry.setApplicationDestinationPrefixes("/pub",
-			"/sub"); //클라이언트에서 메세지 송신 시 붙일 prefix 정의 - 클라이언트가 메세지를 보낼때
+		registry.setApplicationDestinationPrefixes("/pub", "/sub"); //클라이언트에서 메세지 송신 시 붙일 prefix 정의 - 클라이언트가 메세지를 보낼때
 	}
 
 
@@ -50,6 +52,4 @@ public class StompConfiguration implements WebSocketMessageBrokerConfigurer {
 	public void configureClientInboundChannel(ChannelRegistration registration) {
 		registration.interceptors(stompHandler);
 	}
-
-
 }

--- a/src/main/java/com/gnimty/communityapiserver/global/connect/SessionInfo.java
+++ b/src/main/java/com/gnimty/communityapiserver/global/connect/SessionInfo.java
@@ -1,25 +1,23 @@
 package com.gnimty.communityapiserver.global.connect;
 
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Data;
-import org.joda.time.DateTime;
 
 @Data
 @AllArgsConstructor
 public class SessionInfo {
 
 	private Long memberId;
-	private long expirationTime;
+	private LocalDateTime expirationTime;
 
 	@Override
 	public String toString() {
-		String dateTime = new DateTime(this.expirationTime).toString();
-
 		return String.format("""
-                [memberId  = %d,\t\texpirationTime   = %s]
-                """,
+				[memberId  = %d,\t\texpirationTime   = %s]
+				""",
 			memberId,
-			dateTime
+			expirationTime.toString()
 		);
 	}
 }

--- a/src/main/java/com/gnimty/communityapiserver/global/connect/SessionInfo.java
+++ b/src/main/java/com/gnimty/communityapiserver/global/connect/SessionInfo.java
@@ -1,0 +1,25 @@
+package com.gnimty.communityapiserver.global.connect;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import org.joda.time.DateTime;
+
+@Data
+@AllArgsConstructor
+public class SessionInfo {
+
+	private Long memberId;
+	private long expirationTime;
+
+	@Override
+	public String toString() {
+		String dateTime = new DateTime(this.expirationTime).toString();
+
+		return String.format("""
+                [memberId  = %d,\t\texpirationTime   = %s]
+                """,
+			memberId,
+			dateTime
+		);
+	}
+}

--- a/src/main/java/com/gnimty/communityapiserver/global/connect/WebSocketSessionManager.java
+++ b/src/main/java/com/gnimty/communityapiserver/global/connect/WebSocketSessionManager.java
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class WebSocketSessionManager {
 
-	private static Map<String, SessionInfo> sessionStore = new ConcurrentHashMap<>();
+	private static final Map<String, SessionInfo> sessionStore = new ConcurrentHashMap<>();
 
 	private static final long SESSION_TIMEOUT = 60 * 60 * 1000;
 	private static final long ZOMBIE_CHECK_TIME = 24 * 60 * 60 * 1000;
@@ -34,7 +34,7 @@ public class WebSocketSessionManager {
 
 	public int getSessionCountByMemberId(Long memberId) {
 		return (int) sessionStore.values().stream()
-			.filter(memberId::equals)
+			.filter(value -> value.getMemberId().equals(memberId))
 			.count();
 	}
 
@@ -43,7 +43,7 @@ public class WebSocketSessionManager {
 		sessionStore.values().removeIf(session -> isBeforeNow(session.getExpirationTime()));
 	}
 
-	@Scheduled(fixedRate = 5000)
+	@Scheduled(fixedRate = ZOMBIE_CHECK_TIME)
 	private void log() {
 		List<SessionInfo> zombieSessions = sessionStore.values().stream()
 			.filter(sessionInfo -> isBeforeNow(sessionInfo.getExpirationTime()))

--- a/src/main/java/com/gnimty/communityapiserver/global/connect/WebSocketSessionManager.java
+++ b/src/main/java/com/gnimty/communityapiserver/global/connect/WebSocketSessionManager.java
@@ -1,9 +1,12 @@
 package com.gnimty.communityapiserver.global.connect;
 
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -11,10 +14,14 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class WebSocketSessionManager {
 
-	private static Map<String, Long> sessionStore = new ConcurrentHashMap<>();
+	private static Map<String, SessionInfo> sessionStore = new ConcurrentHashMap<>();
+
+	private static final long SESSION_TIMEOUT = 60 * 60 * 1000;
+	private static final long ZOMBIE_CHECK_TIME = 24 * 60 * 60 * 1000;
 
 	public void addSession(String sessionId, Long memberId) {
-		sessionStore.put(sessionId, memberId);
+		long sessionExpireTime = System.currentTimeMillis() + SESSION_TIMEOUT;
+		sessionStore.put(sessionId, new SessionInfo(memberId, sessionExpireTime));
 	}
 
 	public void deleteSession(String sessionId) {
@@ -22,7 +29,7 @@ public class WebSocketSessionManager {
 	}
 
 	public Long getMemberId(String sessionId) {
-		return sessionStore.get(sessionId);
+		return sessionStore.get(sessionId).getMemberId();
 	}
 
 	public int getSessionCountByMemberId(Long memberId) {
@@ -31,4 +38,30 @@ public class WebSocketSessionManager {
 			.count();
 	}
 
+	@Scheduled(fixedRate = SESSION_TIMEOUT)
+	private void cleanExpiredSessions() {
+		long currentTime = System.currentTimeMillis();
+		sessionStore.entrySet().removeIf(session -> session.getValue().getExpirationTime() < currentTime);
+	}
+
+	@Scheduled(fixedRate = ZOMBIE_CHECK_TIME)
+	private void log() {
+		long currentTime = System.currentTimeMillis();
+
+		List<SessionInfo> zombieSessions = sessionStore.values().stream()
+			.filter(sessionInfo -> sessionInfo.getExpirationTime() < currentTime)
+			.toList();
+
+		log.info("""
+          
+        [ZombieSession]
+            count: {}
+            Sessions:
+            				{}
+        """
+			, zombieSessions.size(), zombieSessions.stream()
+				.map(Object::toString)
+				.collect(Collectors.joining("\n\t\t\t\t\t\t")));
+
+	}
 }

--- a/src/main/java/com/gnimty/communityapiserver/global/connect/WebSocketSessionManager.java
+++ b/src/main/java/com/gnimty/communityapiserver/global/connect/WebSocketSessionManager.java
@@ -14,7 +14,6 @@ public class WebSocketSessionManager {
 	private static Map<String, Long> sessionStore = new ConcurrentHashMap<>();
 
 	public void addSession(String sessionId, Long memberId) {
-		log.info("sessionId: {}  memberId: {}", sessionId, memberId);
 		sessionStore.put(sessionId, memberId);
 	}
 

--- a/src/main/java/com/gnimty/communityapiserver/global/constant/CacheType.java
+++ b/src/main/java/com/gnimty/communityapiserver/global/constant/CacheType.java
@@ -2,6 +2,7 @@ package com.gnimty.communityapiserver.global.constant;
 
 import static com.gnimty.communityapiserver.global.constant.Auth.EMAIL_CODE_EXPIRATION;
 import static com.gnimty.communityapiserver.global.constant.Auth.PASSWORD_EXPIRATION;
+import static com.gnimty.communityapiserver.global.constant.Auth.REFRESH_TOKEN_EXPIRATION;
 import static com.gnimty.communityapiserver.global.constant.Auth.SIGNUP_EXPIRATION;
 
 import lombok.AllArgsConstructor;
@@ -11,7 +12,7 @@ import lombok.Getter;
 @Getter
 public enum CacheType {
 
-	REFRESH_TOKEN("refreshTokenCache", PASSWORD_EXPIRATION.getExpiration(), 10000),
+	REFRESH_TOKEN("refreshTokenCache", REFRESH_TOKEN_EXPIRATION.getExpiration(), 10000),
 	SIGNUP_VERIFIED("signupVerifiedCache", SIGNUP_EXPIRATION.getExpiration(), 1000),
 	SIGNUP_EMAIL_CODE("signupEmailCodeCache", EMAIL_CODE_EXPIRATION.getExpiration(), 1000),
 	RESET_PASSWORD_EMAIL_CODE("resetPasswordEmailCodeCache", EMAIL_CODE_EXPIRATION.getExpiration(), 1000),

--- a/src/main/java/com/gnimty/communityapiserver/global/filter/HttpLog.java
+++ b/src/main/java/com/gnimty/communityapiserver/global/filter/HttpLog.java
@@ -32,7 +32,9 @@ public class HttpLog {
 		this.method = requestWrapper.getMethod();
 		this.host = requestWrapper.getRemoteHost();
 		this.requestUri = requestWrapper.getRequestURI();
-		this.requestParam = requestWrapper.getParameterMap().values().toString();
+		this.requestParam = requestWrapper.getParameterMap().entrySet().stream()
+			.map(entry -> entry.getKey() + "=[" + String.join(",", entry.getValue()) + "]")
+			.collect(Collectors.joining(", "));
 		this.requestHeaders = Collections.list(requestWrapper.getHeaderNames()).stream()
 			.map(headerName -> headerName + ": " + requestWrapper.getHeader(headerName))
 			.collect(Collectors.joining(", "));

--- a/src/main/java/com/gnimty/communityapiserver/global/filter/RequestResponseLoggingFilter.java
+++ b/src/main/java/com/gnimty/communityapiserver/global/filter/RequestResponseLoggingFilter.java
@@ -2,6 +2,7 @@ package com.gnimty.communityapiserver.global.filter;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.util.Arrays;
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -18,11 +19,23 @@ import org.springframework.web.util.ContentCachingResponseWrapper;
 @Component
 public class RequestResponseLoggingFilter extends OncePerRequestFilter {
 
+	public static final String[] BLACK_LIST = {
+		"/community/v3/api-docs",
+		"/community/swagger-ui/index.html",
+		"/community/swagger-ui/swagger-initializer.js",
+		"/community/v3/api-docs/swagger-config",
+	};
+
 	@Override
 	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
 		throws ServletException, IOException {
 		ContentCachingRequestWrapper requestWrapper = new ContentCachingRequestWrapper(request);
 		ContentCachingResponseWrapper responseWrapper = new ContentCachingResponseWrapper(response);
+
+		if (Arrays.stream(BLACK_LIST).anyMatch(uri -> request.getRequestURI().equals(uri))) {
+			filterChain.doFilter(request, response);
+			return;
+		}
 
 		long start = System.currentTimeMillis();
 		filterChain.doFilter(requestWrapper, responseWrapper);

--- a/src/main/java/com/gnimty/communityapiserver/global/handler/StompHandler.java
+++ b/src/main/java/com/gnimty/communityapiserver/global/handler/StompHandler.java
@@ -49,6 +49,8 @@ public class StompHandler implements ChannelInterceptor {
 		return message;
 	}
 
+
+
 	private String parseTokenByHeader(StompHeaderAccessor accessor) {
 		String token = jwtProvider.extractJwt(accessor);
 		if (token == null) {

--- a/src/main/java/com/gnimty/communityapiserver/global/handler/StompLog.java
+++ b/src/main/java/com/gnimty/communityapiserver/global/handler/StompLog.java
@@ -1,0 +1,30 @@
+package com.gnimty.communityapiserver.global.handler;
+
+import lombok.Builder;
+
+public class StompLog {
+	private final String command;
+	private final String destination;
+	private final String sessionId;
+
+	@Builder
+	public StompLog(String command, String destination, String sessionId) {
+		this.command = command;
+		this.destination = destination;
+		this.sessionId = sessionId;
+	}
+
+	@Override
+	public String toString() {
+		return String.format("""
+				chat client:
+				    Command         = %s
+				    Destination     = %s
+				    SessionId       = %s
+				    """,
+			this.command,
+			this.destination,
+			this.sessionId
+		);
+	}
+}

--- a/src/main/java/com/gnimty/communityapiserver/global/handler/StompLog.java
+++ b/src/main/java/com/gnimty/communityapiserver/global/handler/StompLog.java
@@ -17,10 +17,11 @@ public class StompLog {
 	@Override
 	public String toString() {
 		return String.format("""
+    
 				chat client:
-				    Command         = %s
-				    Destination     = %s
-				    SessionId       = %s
+				    Command      = %s
+				    Destination  = %s
+				    SessionId    = %s
 				    """,
 			this.command,
 			this.destination,

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -70,7 +70,7 @@ spring:
     properties:
       hibernate:
         hbm2ddl:
-          auto: create-drop
+          auto: update
         format_sql: true
     show-sql: true
 
@@ -94,6 +94,11 @@ logging:
           mongodb:
             core:
               MongoTemplate: DEBUG
+        web:
+          socket:
+            config:
+              WebSocketMessageBrokerStats: ERROR
+
 ---
 spring:
   config:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -38,7 +38,7 @@ spring:
           timeout: 10000
           starttls:
             enable: true
-        debug: true
+        debug: false
         transport:
           protocol: smtp
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -70,7 +70,7 @@ spring:
     properties:
       hibernate:
         hbm2ddl:
-          auto: update
+          auto: create-drop
         format_sql: true
     show-sql: true
 


### PR DESCRIPTION
### 1. 채팅 서비스 로깅 작업

로깅 시점
 - 웹소켓 연결
 - 웹소켓 연결 해제
 - 사용자가 stomp로 Message SEND 시
  (서버에서 사용자에게 보내는 로깅 작업은 뺏음)
  (이유: 사용자가 서버에 보내고 오류도 기록되기 때문에 불필요하다고 판단. 그리고 실시간 서비스이기 때문)
 - 24시간 마다 좀비 세션 확인


### 2. 세션 관리
한 시간마다 웹소켓이 자동으로 연결 해제 됨으로, 한 시간 마다 좀비세션을 삭제함
 
 