### PR TITLE
Feat/#170 withdrawal

### DIFF
--- a/src/main/java/com/gnimty/communityapiserver/domain/block/entity/Block.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/block/entity/Block.java
@@ -17,6 +17,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Where;
 
 @Entity
 @Table(
@@ -30,6 +31,7 @@ import lombok.NoArgsConstructor;
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
+@Where(clause = "deleted = 0")
 public class Block extends BaseEntity {
 
 	@Id

--- a/src/main/java/com/gnimty/communityapiserver/domain/block/repository/BlockQueryRepository.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/block/repository/BlockQueryRepository.java
@@ -17,7 +17,7 @@ public class BlockQueryRepository {
 		return queryFactory
 			.selectOne()
 			.from(block)
-			.where(block.blocker.id.eq(blocker.getId()), block.blocked.id.eq(blocked.getId()))
+			.where(block.blocker.id.eq(blocker.getId()), block.blocked.id.eq(blocked.getId()), block.deleted.isFalse())
 			.fetchFirst() != null;
 	}
 
@@ -25,7 +25,7 @@ public class BlockQueryRepository {
 		return queryFactory
 			.selectOne()
 			.from(block)
-			.where(block.blocker.id.eq(blockerId), block.blocked.id.eq(blockedId))
+			.where(block.blocker.id.eq(blockerId), block.blocked.id.eq(blockedId), block.deleted.isFalse())
 			.fetchFirst() != null;
 	}
 }

--- a/src/main/java/com/gnimty/communityapiserver/domain/block/repository/BlockRepository.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/block/repository/BlockRepository.java
@@ -2,6 +2,7 @@ package com.gnimty.communityapiserver.domain.block.repository;
 
 import com.gnimty.communityapiserver.domain.block.entity.Block;
 import com.gnimty.communityapiserver.domain.member.entity.Member;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -12,7 +13,7 @@ public interface BlockRepository extends JpaRepository<Block, Long> {
 
 	List<Block> findByBlocker(Member blocker);
 
-	@Query("delete from Block b where b.blocker.id = :id or b.blocked.id = :id")
+	@Query("update Block b set b.deleted = 1, b.updatedAt = :updatedAt where b.blocker.id = :id or b.blocked.id = :id")
 	@Modifying
-	void deleteAllFromMember(@Param("id") Long id);
+	void deleteAllFromMember(@Param("id") Long id, @Param("updatedAt") LocalDateTime updatedAt);
 }

--- a/src/main/java/com/gnimty/communityapiserver/domain/block/service/BlockService.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/block/service/BlockService.java
@@ -38,7 +38,7 @@ public class BlockService {
 		if (!Objects.equals(block.getBlocker().getId(), member.getId())) {
 			throw new BaseException(ErrorCode.NO_PERMISSION);
 		}
-		blockRepository.delete(block);
+		block.delete();
 	}
 
 	private Block createBlockEntity(BlockServiceRequest request, Member member, Member blocked) {

--- a/src/main/java/com/gnimty/communityapiserver/domain/championcomments/entity/ChampionComments.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/championcomments/entity/ChampionComments.java
@@ -77,14 +77,15 @@ public class ChampionComments extends BaseEntity {
 	@Column(name = "version", columnDefinition = "VARCHAR(20)")
 	private String version;
 
-	@ManyToOne(fetch = FetchType.LAZY, optional = false)
-	@JoinColumn(name = "member_id", nullable = false)
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id")
 	private Member member;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "parent_champion_comments_id")
 	private ChampionComments parentChampionComments;
 
+	@Column(name = "lock_version")
 	@Version
 	private Long lockVersion;
 
@@ -117,20 +118,6 @@ public class ChampionComments extends BaseEntity {
 		this.parentChampionComments = parentChampionComments;
 	}
 
-	public void updateLane(Lane lane) {
-		if (lane == null) {
-			return;
-		}
-		this.lane = lane;
-	}
-
-	public void updateOpponentChampionId(Long opponentChampionId) {
-		if (opponentChampionId == null) {
-			return;
-		}
-		this.opponentChampionId = opponentChampionId;
-	}
-
 	public void updateMentionedMemberId(Long mentionedMemberId) {
 		if (mentionedMemberId == null) {
 			return;
@@ -148,5 +135,11 @@ public class ChampionComments extends BaseEntity {
 
 	public void increaseDownCount() {
 		this.downCount++;
+	}
+
+	@Override
+	public void delete() {
+		super.delete();
+		member = null;
 	}
 }

--- a/src/main/java/com/gnimty/communityapiserver/domain/championcomments/repository/ChampionCommentsRepository.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/championcomments/repository/ChampionCommentsRepository.java
@@ -1,8 +1,15 @@
 package com.gnimty.communityapiserver.domain.championcomments.repository;
 
 import com.gnimty.communityapiserver.domain.championcomments.entity.ChampionComments;
+import java.time.LocalDateTime;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ChampionCommentsRepository extends JpaRepository<ChampionComments, Long> {
 
+	@Query("update ChampionComments c set c.deleted = 1, c.member.id = null, c.updatedAt = :updatedAt where c.member.id = :id")
+	@Modifying
+	void deleteAllFromMember(@Param("id") Long id, @Param("updatedAt") LocalDateTime updatedAt);
 }

--- a/src/main/java/com/gnimty/communityapiserver/domain/championcommentslike/entity/ChampionCommentsLike.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/championcommentslike/entity/ChampionCommentsLike.java
@@ -18,6 +18,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Where;
 
 @Entity
 @Table(
@@ -28,6 +29,7 @@ import lombok.NoArgsConstructor;
 )
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Where(clause = "deleted = 0")
 public class ChampionCommentsLike extends BaseEntity {
 
 	@Id

--- a/src/main/java/com/gnimty/communityapiserver/domain/championcommentslike/repository/ChampionCommentsLikeQueryRepository.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/championcommentslike/repository/ChampionCommentsLikeQueryRepository.java
@@ -19,7 +19,8 @@ public class ChampionCommentsLikeQueryRepository {
 			.selectOne()
 			.from(championCommentsLike)
 			.where(championCommentsLike.member.id.eq(member.getId()),
-				championCommentsLike.championComments.id.eq(championComments.getId()))
+				championCommentsLike.championComments.id.eq(championComments.getId()),
+				championCommentsLike.deleted.isFalse())
 			.fetchFirst() != null;
 	}
 }

--- a/src/main/java/com/gnimty/communityapiserver/domain/championcommentslike/repository/ChampionCommentsLikeRepository.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/championcommentslike/repository/ChampionCommentsLikeRepository.java
@@ -3,10 +3,21 @@ package com.gnimty.communityapiserver.domain.championcommentslike.repository;
 import com.gnimty.communityapiserver.domain.championcomments.entity.ChampionComments;
 import com.gnimty.communityapiserver.domain.championcommentslike.entity.ChampionCommentsLike;
 import com.gnimty.communityapiserver.domain.member.entity.Member;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ChampionCommentsLikeRepository extends JpaRepository<ChampionCommentsLike, Long> {
 
 	Optional<ChampionCommentsLike> findByMemberAndChampionComments(Member member, ChampionComments championComments);
+
+	@Query("update ChampionCommentsLike cl set cl.deleted = 1 where cl.member.id = :id")
+	@Modifying
+	void deleteAllFromMember(@Param("id") Long id);
+
+	@Query("select cl.championComments.id from ChampionCommentsLike cl where cl.member.id = :id and cl.likeOrNot = :likeOrNot")
+	List<Long> findByMemberIdAndLikeOrNot(@Param("id") Long id, @Param("likeOrNot") Boolean likeOrNot);
 }

--- a/src/main/java/com/gnimty/communityapiserver/domain/championcommentslike/service/ChampionCommentsLikeService.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/championcommentslike/service/ChampionCommentsLikeService.java
@@ -49,7 +49,7 @@ public class ChampionCommentsLikeService {
 	private void cancelChampionCommentsLike(Member member, ChampionComments championComments) {
 		ChampionCommentsLike championCommentsLike = championCommentsLikeReadService
 			.findByMemberAndChampionComments(member, championComments);
-		championCommentsLikeRepository.delete(championCommentsLike);
+		championCommentsLike.delete();
 	}
 
 	private void championCommentsLike(

--- a/src/main/java/com/gnimty/communityapiserver/domain/championcommentsreport/entity/ChampionCommentsReport.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/championcommentsreport/entity/ChampionCommentsReport.java
@@ -22,6 +22,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Where;
 
 @Entity
 @Table(
@@ -30,11 +31,12 @@ import lombok.NoArgsConstructor;
 		@Index(name = "member_id_champion_comments_id_idx", columnList = "member_id, champion_comments_id")
 	},
 	uniqueConstraints = {
-		@UniqueConstraint(name = "member_champion_comments_id_unique_constraints", columnNames = {"member_id", "champion_comments_id"})
+		@UniqueConstraint(name = "member_champion_comments_id_unique_constraints", columnNames = {"member_id", "champion_comments_id", "deleted"})
 	}
 )
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Where(clause = "deleted = 0")
 public class ChampionCommentsReport extends BaseEntity {
 
 	@Id

--- a/src/main/java/com/gnimty/communityapiserver/domain/championcommentsreport/reposiotry/ChampionCommentsReportQueryRepository.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/championcommentsreport/reposiotry/ChampionCommentsReportQueryRepository.java
@@ -18,7 +18,7 @@ public class ChampionCommentsReportQueryRepository {
 	public boolean existsByMemberAndChampionComments(Member member, ChampionComments championComments) {
 		return queryFactory.selectOne()
 			.from(championCommentsReport)
-			.where(memberIdEq(member), championCommentsIdEq(championComments))
+			.where(memberIdEq(member), championCommentsIdEq(championComments), championCommentsReport.deleted.isFalse())
 			.fetchFirst() != null;
 	}
 

--- a/src/main/java/com/gnimty/communityapiserver/domain/championcommentsreport/reposiotry/ChampionCommentsReportRepository.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/championcommentsreport/reposiotry/ChampionCommentsReportRepository.java
@@ -1,8 +1,15 @@
 package com.gnimty.communityapiserver.domain.championcommentsreport.reposiotry;
 
 import com.gnimty.communityapiserver.domain.championcommentsreport.entity.ChampionCommentsReport;
+import java.time.LocalDateTime;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ChampionCommentsReportRepository extends JpaRepository<ChampionCommentsReport, Long> {
 
+	@Query("update ChampionCommentsReport cr set cr.deleted = 1, cr.updatedAt = :updatedAt where cr.member.id = :id")
+	@Modifying
+	void deleteAllFromMember(@Param("id") Long id, @Param("updatedAt") LocalDateTime updatedAt);
 }

--- a/src/main/java/com/gnimty/communityapiserver/domain/introduction/entity/Introduction.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/introduction/entity/Introduction.java
@@ -17,6 +17,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Where;
 
 @Entity
 @Table(
@@ -27,6 +28,7 @@ import lombok.NoArgsConstructor;
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
+@Where(clause = "deleted = 0")
 public class Introduction extends BaseEntity {
 
 	@Id

--- a/src/main/java/com/gnimty/communityapiserver/domain/introduction/repository/IntroductionRepository.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/introduction/repository/IntroductionRepository.java
@@ -2,6 +2,7 @@ package com.gnimty.communityapiserver.domain.introduction.repository;
 
 import com.gnimty.communityapiserver.domain.introduction.entity.Introduction;
 import com.gnimty.communityapiserver.domain.member.entity.Member;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -14,7 +15,7 @@ public interface IntroductionRepository extends JpaRepository<Introduction, Long
 
 	Long countByMemberAndIsMain(Member member, Boolean isMain);
 
-	@Query("delete from Introduction i where i.member.id = :id")
+	@Query("update Introduction i set i.deleted = 1, i.updatedAt = :updatedAt where i.member.id = :id")
 	@Modifying
-	void deleteAllFromMember(@Param("id") Long id);
+	void deleteAllFromMember(@Param("id") Long id, @Param("updatedAt") LocalDateTime updatedAt);
 }

--- a/src/main/java/com/gnimty/communityapiserver/domain/member/controller/MemberController.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/member/controller/MemberController.java
@@ -197,10 +197,11 @@ public class MemberController {
 	@Operation(summary = WITHDRAWAL, description = ApiDescription.WITHDRAWAL)
 	@Parameter(in = ParameterIn.COOKIE, name = "accessToken", description = "인증을 위한 Access Token", required = true)
 	@DeleteMapping("/me")
-	public CommonResponse<Void> withdrawal() {
+	public CommonResponse<Void> withdrawal(HttpServletResponse response) {
 		Member member = MemberThreadLocal.get();
 		memberService.withdrawal();
 		stompService.withdrawal(member.getId());
+		expireCookie(response);
 		return CommonResponse.success(SUCCESS_WITHDRAWAL, OK);
 	}
 

--- a/src/main/java/com/gnimty/communityapiserver/domain/member/entity/Member.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/member/entity/Member.java
@@ -17,6 +17,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Where;
 
 @Entity
 @Table(
@@ -27,6 +28,7 @@ import lombok.NoArgsConstructor;
 )
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Where(clause = "deleted = 0")
 public class Member extends BaseEntity {
 
 	@Id
@@ -38,7 +40,7 @@ public class Member extends BaseEntity {
 	@NotNull
 	private Boolean rsoLinked;
 
-	@Column(name = "email", columnDefinition = "VARCHAR(100)", unique = true)
+	@Column(name = "email", columnDefinition = "VARCHAR(100)")
 	private String email;
 
 	@Column(name = "password", columnDefinition = "VARCHAR(100)")
@@ -47,7 +49,7 @@ public class Member extends BaseEntity {
 	@Column(name = "favorite_champion_id", columnDefinition = "BIGINT")
 	private Long favoriteChampionID;
 
-	@Column(name = "nickname", columnDefinition = "VARCHAR(16)", unique = true)
+	@Column(name = "nickname", columnDefinition = "VARCHAR(16)")
 	private String nickname;
 
 	@Enumerated(EnumType.STRING)
@@ -58,6 +60,7 @@ public class Member extends BaseEntity {
 	@NotNull
 	private Long upCount;
 
+	@Column(name = "lock_version")
 	@Version
 	private Long lockVersion;
 

--- a/src/main/java/com/gnimty/communityapiserver/domain/member/repository/MemberQueryRepository.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/member/repository/MemberQueryRepository.java
@@ -29,7 +29,7 @@ public class MemberQueryRepository {
 		return queryFactory
 			.selectOne()
 			.from(member)
-			.where(member.email.eq(email))
+			.where(member.email.eq(email), member.deleted.isFalse())
 			.fetchFirst() != null;
 	}
 
@@ -37,25 +37,24 @@ public class MemberQueryRepository {
 		return queryFactory
 			.selectOne()
 			.from(member)
-			.where(member.id.eq(id))
+			.where(member.id.eq(id), member.deleted.isFalse())
 			.fetchFirst() != null;
 	}
 
 	public OtherProfileServiceResponse findOtherById(Long id) {
 		List<Schedule> schedules = queryFactory
 			.selectFrom(schedule)
-			.join(schedule.member, member).on(schedule.member.id.eq(member.id))
+			.join(schedule.member, member).on(schedule.member.id.eq(member.id), schedule.deleted.isFalse())
 			.where(schedule.member.id.eq(id))
 			.fetch();
 		Optional<Introduction> mainIntroduction = Optional.ofNullable(queryFactory
 			.selectFrom(introduction)
-			.join(introduction.member)
-			.where(introduction.member.id.eq(id), isMainIntroduction())
+			.join(introduction.member).on(introduction.member.id.eq(member.id), introduction.deleted.isFalse())
+			.where(isMainIntroduction())
 			.fetchFirst());
 		List<PreferGameMode> preferGameModes = queryFactory
 			.selectFrom(preferGameMode)
-			.join(preferGameMode.member)
-			.where(preferGameMode.member.id.eq(id))
+			.join(preferGameMode.member).on(preferGameMode.member.id.eq(member.id), preferGameMode.deleted.isFalse())
 			.fetch();
 
 		return OtherProfileServiceResponse.builder()
@@ -72,7 +71,7 @@ public class MemberQueryRepository {
 	public Long findUpCountByPuuid(String puuid) {
 		return queryFactory.select(member.upCount)
 			.from(member)
-			.join(riotAccount).on(memberEq())
+			.join(riotAccount).on(memberEq(), riotAccount.deleted.isFalse())
 			.where(puuidEq(puuid))
 			.fetchFirst();
 	}

--- a/src/main/java/com/gnimty/communityapiserver/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/member/repository/MemberRepository.java
@@ -1,10 +1,18 @@
 package com.gnimty.communityapiserver.domain.member.repository;
 
 import com.gnimty.communityapiserver.domain.member.entity.Member;
+import java.time.LocalDateTime;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
 	Optional<Member> findByEmail(String email);
+
+	@Query("update Member m set m.deleted = 1, m.updatedAt = :updatedAt where m.id = :id")
+	@Modifying
+	void deleteAllFromMember(@Param("id") Long id, @Param("updatedAt") LocalDateTime updatedAt);
 }

--- a/src/main/java/com/gnimty/communityapiserver/domain/member/service/MemberService.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/member/service/MemberService.java
@@ -259,7 +259,7 @@ public class MemberService {
 			throw new BaseException(ErrorCode.NOT_LOGIN_BY_FORM);
 		}
 		OauthInfo oauthInfo = oauthInfoReadService.findByMemberAndProvider(member, provider);
-		oauthInfoRepository.delete(oauthInfo);
+		oauthInfo.delete();
 	}
 
 	public void logout() {

--- a/src/main/java/com/gnimty/communityapiserver/domain/member/service/MemberService.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/member/service/MemberService.java
@@ -269,7 +269,7 @@ public class MemberService {
 
 	public void withdrawal() {
 		Member member = MemberThreadLocal.get();
-		withdrawalService.withDrawal(member.getId());
+		withdrawalService.withdrawal(member.getId());
 		cacheService.evict(REFRESH_TOKEN, getCacheKey(REFRESH, member.getId().toString()));
 	}
 

--- a/src/main/java/com/gnimty/communityapiserver/domain/member/service/WithdrawalService.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/member/service/WithdrawalService.java
@@ -1,0 +1,167 @@
+package com.gnimty.communityapiserver.domain.member.service;
+
+import com.gnimty.communityapiserver.domain.block.repository.BlockRepository;
+import com.gnimty.communityapiserver.domain.championcomments.entity.ChampionComments;
+import com.gnimty.communityapiserver.domain.championcomments.repository.ChampionCommentsRepository;
+import com.gnimty.communityapiserver.domain.championcommentslike.repository.ChampionCommentsLikeRepository;
+import com.gnimty.communityapiserver.domain.championcommentsreport.reposiotry.ChampionCommentsReportRepository;
+import com.gnimty.communityapiserver.domain.introduction.repository.IntroductionRepository;
+import com.gnimty.communityapiserver.domain.member.entity.Member;
+import com.gnimty.communityapiserver.domain.member.repository.MemberRepository;
+import com.gnimty.communityapiserver.domain.memberlike.repository.MemberLikeRepository;
+import com.gnimty.communityapiserver.domain.oauthinfo.repository.OauthInfoRepository;
+import com.gnimty.communityapiserver.domain.prefergamemode.repository.PreferGameModeRepository;
+import com.gnimty.communityapiserver.domain.riotaccount.repository.RiotAccountRepository;
+import com.gnimty.communityapiserver.domain.schedule.repository.ScheduleRepository;
+import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import javax.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class WithdrawalService {
+
+	private static final int MAXIMUM_RETRY = 10;
+	private static final String WITHDRAWAL_SCHEDULER_CRON_EXPRESSION = "0 0 5 * * *";
+	private static final String[] QUERY_PARAMS = {
+		"introduction",
+		"prefer_game_mode",
+		"schedule",
+		"block",
+		"oauth_info",
+		"member_like",
+		"riot_account",
+		"champion_comments_like",
+		"champion_comments_report",
+		"member"
+	};
+	private static final String UPDATE_MEMBER_SQL = """
+			update member m
+			set m.up_count = m.up_count - 1, m.lock_version = m.lock_version + 1, m.updated_at = ?
+			where m.member_id = ?
+			and m.lock_version = ?
+		""";
+	private static final String UPDATE_CHAMPION_COMMENTS_LIKE_SQL = """
+			update champion_comments c
+			set c.up_count = c.up_count - 1, c.lock_version = c.lock_version + 1, c.updated_at = ?
+			where c.champion_comments_id = ?
+			and c.lock_version = ?
+		""";
+	private static final String UPDATE_CHAMPION_COMMENTS_DISLIKE_SQL = """
+			update champion_comments c
+			set c.down_count = c.down_count - 1, c.lock_version = c.lock_version + 1, c.updated_at = ?
+			where c.champion_comments_id = ?
+			and c.lock_version = ?
+		""";
+
+	private final IntroductionRepository introductionRepository;
+	private final PreferGameModeRepository preferGameModeRepository;
+	private final ScheduleRepository scheduleRepository;
+	private final BlockRepository blockRepository;
+	private final OauthInfoRepository oauthInfoRepository;
+	private final MemberLikeRepository memberLikeRepository;
+	private final RiotAccountRepository riotAccountRepository;
+	private final ChampionCommentsLikeRepository championCommentsLikeRepository;
+	private final ChampionCommentsReportRepository championCommentsReportRepository;
+	private final ChampionCommentsRepository championCommentsRepository;
+	private final MemberRepository memberRepository;
+	private final JdbcTemplate jdbcTemplate;
+	private final EntityManager entityManager;
+
+	public void withdrawal(Long id) {
+		LocalDateTime now = LocalDateTime.now();
+		introductionRepository.deleteAllFromMember(id, now);
+		preferGameModeRepository.deleteAllFromMember(id, now);
+		scheduleRepository.deleteAllFromMember(id, now);
+		blockRepository.deleteAllFromMember(id, now);
+		oauthInfoRepository.deleteAllFromMember(id, now);
+		memberLikeDelete(id, now);
+		riotAccountRepository.deleteAllFromMember(id, now);
+		championCommentsLikeDelete(id, now);
+		championCommentsReportRepository.deleteAllFromMember(id, now);
+		championCommentsRepository.deleteAllFromMember(id, now);
+		memberRepository.deleteAllFromMember(id, now);
+	}
+
+	private void memberLikeDelete(Long id, LocalDateTime now) {
+		memberLikeRepository.deleteAllFromMember(id);
+		List<Long> targetIds = memberLikeRepository.findTargetIdsBySourceMemberId(id);
+		targetIds.forEach(targetId -> {
+			int rowsUpdated = 0;
+			int retryCount = 0;
+			while (rowsUpdated != 1 && retryCount < MAXIMUM_RETRY) {
+				Optional<Member> optionalMember = memberRepository.findById(targetId);
+				if (optionalMember.isEmpty()) {
+					return;
+				}
+				Member updateMember = optionalMember.get();
+				rowsUpdated = jdbcTemplate.update(UPDATE_MEMBER_SQL, ps -> {
+					ps.setTimestamp(1, Timestamp.valueOf(now));
+					ps.setLong(2, updateMember.getId());
+					ps.setLong(3, updateMember.getLockVersion());
+				});
+				retryCount++;
+			}
+			entityManager.flush();
+			entityManager.clear();
+		});
+	}
+
+	private void championCommentsLikeDelete(Long id, LocalDateTime now) {
+		championCommentsLikeRepository.deleteAllFromMember(id);
+		List<Long> championCommentsLikeIds = championCommentsLikeRepository.findByMemberIdAndLikeOrNot(id, true);
+		List<Long> championCommentsDislikeIds = championCommentsLikeRepository.findByMemberIdAndLikeOrNot(id, false);
+
+		updateChampionCommentsReaction(now, championCommentsLikeIds, UPDATE_CHAMPION_COMMENTS_LIKE_SQL);
+		updateChampionCommentsReaction(now, championCommentsDislikeIds, UPDATE_CHAMPION_COMMENTS_DISLIKE_SQL);
+	}
+
+	private void updateChampionCommentsReaction(LocalDateTime now, List<Long> championCommentsLikeIds,
+		String likeUpdateSql) {
+		championCommentsLikeIds.forEach(likeId -> {
+			int rowsUpdated = 0;
+			int retryCount = 0;
+			while (rowsUpdated != 1 && retryCount < MAXIMUM_RETRY) {
+				Optional<ChampionComments> optionalChampionComments = championCommentsRepository.findById(likeId);
+				if (optionalChampionComments.isEmpty()) {
+					return;
+				}
+				ChampionComments championComments = optionalChampionComments.get();
+				rowsUpdated = jdbcTemplate.update(likeUpdateSql, ps -> {
+					ps.setTimestamp(1, Timestamp.valueOf(now));
+					ps.setLong(2, championComments.getId());
+					ps.setLong(3, championComments.getLockVersion());
+				});
+				retryCount++;
+			}
+			entityManager.flush();
+			entityManager.clear();
+		});
+	}
+
+	@Scheduled(cron = WITHDRAWAL_SCHEDULER_CRON_EXPRESSION)
+	public void physicalDeleteDatePassed() {
+		Arrays.stream(QUERY_PARAMS).forEach(this::deleteWhereDeletedAndTimeElapsed);
+	}
+
+	private void deleteWhereDeletedAndTimeElapsed(String entity) {
+		LocalDateTime date = LocalDate.now().atStartOfDay().minusDays(3);
+		String sql = "DELETE FROM " + entity + " e WHERE e.deleted = 1 AND e.updated_at < ?";
+		int rowsUpdated = 0;
+		int retryCount = 0;
+		while (rowsUpdated != 1 && retryCount < MAXIMUM_RETRY) {
+			rowsUpdated = jdbcTemplate.update(sql, ps -> ps.setTimestamp(1, Timestamp.valueOf(date)));
+			retryCount++;
+		}
+	}
+}

--- a/src/main/java/com/gnimty/communityapiserver/domain/member/service/WithdrawalService.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/member/service/WithdrawalService.java
@@ -94,7 +94,6 @@ public class WithdrawalService {
 	}
 
 	private void memberLikeDelete(Long id, LocalDateTime now) {
-		memberLikeRepository.deleteAllFromMember(id);
 		List<Long> targetIds = memberLikeRepository.findTargetIdsBySourceMemberId(id);
 		targetIds.forEach(targetId -> {
 			int rowsUpdated = 0;
@@ -115,15 +114,16 @@ public class WithdrawalService {
 			entityManager.flush();
 			entityManager.clear();
 		});
+		memberLikeRepository.deleteAllFromMember(id);
 	}
 
 	private void championCommentsLikeDelete(Long id, LocalDateTime now) {
-		championCommentsLikeRepository.deleteAllFromMember(id);
 		List<Long> championCommentsLikeIds = championCommentsLikeRepository.findByMemberIdAndLikeOrNot(id, true);
 		List<Long> championCommentsDislikeIds = championCommentsLikeRepository.findByMemberIdAndLikeOrNot(id, false);
 
 		updateChampionCommentsReaction(now, championCommentsLikeIds, UPDATE_CHAMPION_COMMENTS_LIKE_SQL);
 		updateChampionCommentsReaction(now, championCommentsDislikeIds, UPDATE_CHAMPION_COMMENTS_DISLIKE_SQL);
+		championCommentsLikeRepository.deleteAllFromMember(id);
 	}
 
 	private void updateChampionCommentsReaction(LocalDateTime now, List<Long> championCommentsLikeIds,

--- a/src/main/java/com/gnimty/communityapiserver/domain/memberlike/entity/MemberLike.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/memberlike/entity/MemberLike.java
@@ -16,6 +16,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Where;
 
 @Entity
 @Table(
@@ -26,6 +27,7 @@ import lombok.NoArgsConstructor;
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
+@Where(clause = "deleted = 0")
 public class MemberLike extends BaseEntity {
 
 	@Id

--- a/src/main/java/com/gnimty/communityapiserver/domain/memberlike/repository/MemberLikeQueryRepository.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/memberlike/repository/MemberLikeQueryRepository.java
@@ -17,7 +17,8 @@ public class MemberLikeQueryRepository {
 		return queryFactory
 			.selectOne()
 			.from(memberLike)
-			.where(memberLike.sourceMember.id.eq(source.getId()), memberLike.targetMember.id.eq(target.getId()))
+			.where(memberLike.sourceMember.id.eq(source.getId()), memberLike.targetMember.id.eq(target.getId()),
+				memberLike.deleted.isFalse())
 			.fetchFirst() != null;
 	}
 }

--- a/src/main/java/com/gnimty/communityapiserver/domain/memberlike/repository/MemberLikeRepository.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/memberlike/repository/MemberLikeRepository.java
@@ -15,7 +15,10 @@ public interface MemberLikeRepository extends JpaRepository<MemberLike, Long> {
 
 	List<MemberLike> findBySourceMember(Member sourceMember);
 
-	@Query("delete from MemberLike ml where ml.sourceMember.id = :id or ml.targetMember.id = :id")
+	@Query("update MemberLike ml set ml.deleted = 1 where ml.sourceMember.id = :id or ml.targetMember.id = :id")
 	@Modifying
 	void deleteAllFromMember(@Param("id") Long id);
+
+	@Query("select ml.targetMember.id from MemberLike ml where ml.sourceMember.id = :id")
+	List<Long> findTargetIdsBySourceMemberId(@Param("id") Long id);
 }

--- a/src/main/java/com/gnimty/communityapiserver/domain/memberlike/service/MemberLikeService.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/memberlike/service/MemberLikeService.java
@@ -52,6 +52,6 @@ public class MemberLikeService {
 
 	private void cancelMemberLike(Member source, Member target) {
 		MemberLike memberLike = memberLikeReadService.findBySourceAndTarget(source, target);
-		memberLikeRepository.delete(memberLike);
+		memberLike.delete();
 	}
 }

--- a/src/main/java/com/gnimty/communityapiserver/domain/oauthinfo/entity/OauthInfo.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/oauthinfo/entity/OauthInfo.java
@@ -19,6 +19,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Where;
 
 @Entity
 @Table(
@@ -30,6 +31,7 @@ import lombok.NoArgsConstructor;
 )
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Where(clause = "deleted = 0")
 public class OauthInfo extends BaseEntity {
 
 	@Id

--- a/src/main/java/com/gnimty/communityapiserver/domain/oauthinfo/repository/OauthInfoQueryRepository.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/oauthinfo/repository/OauthInfoQueryRepository.java
@@ -18,7 +18,7 @@ public class OauthInfoQueryRepository {
 		return queryFactory
 			.selectOne()
 			.from(oauthInfo)
-			.where(oauthInfo.email.eq(email), oauthInfo.provider.eq(provider))
+			.where(oauthInfo.email.eq(email), oauthInfo.provider.eq(provider), oauthInfo.deleted.isFalse())
 			.fetchFirst() != null;
 	}
 
@@ -26,7 +26,7 @@ public class OauthInfoQueryRepository {
 		return queryFactory
 			.selectOne()
 			.from(oauthInfo)
-			.where(oauthInfo.member.id.eq(member.getId()), oauthInfo.provider.eq(provider))
+			.where(oauthInfo.member.id.eq(member.getId()), oauthInfo.provider.eq(provider), oauthInfo.deleted.isFalse())
 			.fetchFirst() != null;
 	}
 }

--- a/src/main/java/com/gnimty/communityapiserver/domain/oauthinfo/repository/OauthInfoRepository.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/oauthinfo/repository/OauthInfoRepository.java
@@ -3,6 +3,7 @@ package com.gnimty.communityapiserver.domain.oauthinfo.repository;
 import com.gnimty.communityapiserver.domain.member.entity.Member;
 import com.gnimty.communityapiserver.domain.oauthinfo.entity.OauthInfo;
 import com.gnimty.communityapiserver.global.constant.Provider;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -18,7 +19,7 @@ public interface OauthInfoRepository extends JpaRepository<OauthInfo, Long> {
 
 	Optional<OauthInfo> findByMemberAndProvider(Member member, Provider provider);
 
-	@Query("delete from OauthInfo o where o.member.id = :id")
+	@Query("update OauthInfo o set o.deleted = 1, o.updatedAt = :updatedAt where o.member.id = :id")
 	@Modifying
-	void deleteAllFromMember(@Param("id") Long id);
+	void deleteAllFromMember(@Param("id") Long id, @Param("updatedAt") LocalDateTime updatedAt);
 }

--- a/src/main/java/com/gnimty/communityapiserver/domain/prefergamemode/entity/PreferGameMode.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/prefergamemode/entity/PreferGameMode.java
@@ -19,11 +19,13 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Where;
 
 @Entity
 @Table(name = "prefer_game_mode")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Where(clause = "deleted = 0")
 public class PreferGameMode extends BaseEntity {
 
 	@Id

--- a/src/main/java/com/gnimty/communityapiserver/domain/prefergamemode/repository/PreferGameModeRepository.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/prefergamemode/repository/PreferGameModeRepository.java
@@ -2,6 +2,7 @@ package com.gnimty.communityapiserver.domain.prefergamemode.repository;
 
 import com.gnimty.communityapiserver.domain.member.entity.Member;
 import com.gnimty.communityapiserver.domain.prefergamemode.entity.PreferGameMode;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -14,7 +15,7 @@ public interface PreferGameModeRepository extends JpaRepository<PreferGameMode, 
 
 	void deleteByMember(Member member);
 
-	@Query("delete from PreferGameMode p where p.member.id = :id")
+	@Query("update PreferGameMode p set p.deleted = 1, p.updatedAt = :updatedAt where p.member.id = :id")
 	@Modifying
-	void deleteAllFromMember(@Param("id") Long id);
+	void deleteAllFromMember(@Param("id") Long id, @Param("updatedAt") LocalDateTime updatedAt);
 }

--- a/src/main/java/com/gnimty/communityapiserver/domain/riotaccount/entity/RiotAccount.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/riotaccount/entity/RiotAccount.java
@@ -22,6 +22,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Where;
 
 @Entity
 @Table(
@@ -33,6 +34,7 @@ import lombok.NoArgsConstructor;
 )
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Where(clause = "deleted = 0")
 public class RiotAccount extends BaseEntity {
 
 	@Id
@@ -45,7 +47,7 @@ public class RiotAccount extends BaseEntity {
 	private String name;
 
 	@NotNull
-	@Column(name = "internal_tag_name", columnDefinition = "VARCHAR(100)", unique = true)
+	@Column(name = "internal_tag_name", columnDefinition = "VARCHAR(100)")
 	private String internalTagName;
 
 	@NotNull

--- a/src/main/java/com/gnimty/communityapiserver/domain/riotaccount/repository/RiotAccountQueryRepository.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/riotaccount/repository/RiotAccountQueryRepository.java
@@ -48,7 +48,7 @@ public class RiotAccountQueryRepository {
 		return queryFactory
 			.selectOne()
 			.from(riotAccount)
-			.where(riotAccount.puuid.eq(puuid))
+			.where(riotAccount.puuid.eq(puuid), riotAccount.deleted.isFalse())
 			.fetchFirst() != null;
 	}
 
@@ -56,7 +56,7 @@ public class RiotAccountQueryRepository {
 		return queryFactory
 			.selectOne()
 			.from(riotAccount)
-			.where(riotAccount.member.id.eq(member.getId()))
+			.where(riotAccount.member.id.eq(member.getId()), riotAccount.deleted.isFalse())
 			.fetchFirst() != null;
 	}
 
@@ -73,9 +73,9 @@ public class RiotAccountQueryRepository {
 				getProjectionBean(request.getGameMode()))
 			.from(riotAccount)
 			.join(riotAccount.member, member)
-			.leftJoin(preferGameMode).on(preferGameMode.member.eq(member))
-			.leftJoin(introduction).on(introduction.member.eq(member))
-			.leftJoin(schedule).on(schedule.member.eq(member))
+			.leftJoin(preferGameMode).on(preferGameMode.member.eq(member), preferGameMode.deleted.isFalse())
+			.leftJoin(introduction).on(introduction.member.eq(member), introduction.deleted.isFalse())
+			.leftJoin(schedule).on(schedule.member.eq(member), schedule.deleted.isFalse())
 			.where(cursorGt(request),
 				isMainRiotAccount(),
 				excludeMasterGoe(),
@@ -106,9 +106,9 @@ public class RiotAccountQueryRepository {
 				getProjectionBean(gameMode))
 			.from(riotAccount)
 			.join(riotAccount.member, member)
-			.leftJoin(preferGameMode).on(preferGameMode.member.eq(member))
-			.leftJoin(introduction).on(introduction.member.eq(member))
-			.leftJoin(schedule).on(schedule.member.eq(member))
+			.leftJoin(preferGameMode).on(preferGameMode.member.eq(member), preferGameMode.deleted.isFalse())
+			.leftJoin(introduction).on(introduction.member.eq(member), introduction.deleted.isFalse())
+			.leftJoin(schedule).on(schedule.member.eq(member), schedule.deleted.isFalse())
 			.where(memberStatusEq(Status.ONLINE),
 				gameModeEq(gameMode),
 				memberNotEq(me));

--- a/src/main/java/com/gnimty/communityapiserver/domain/riotaccount/repository/RiotAccountRepository.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/riotaccount/repository/RiotAccountRepository.java
@@ -2,6 +2,7 @@ package com.gnimty.communityapiserver.domain.riotaccount.repository;
 
 import com.gnimty.communityapiserver.domain.member.entity.Member;
 import com.gnimty.communityapiserver.domain.riotaccount.entity.RiotAccount;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -18,11 +19,9 @@ public interface RiotAccountRepository extends JpaRepository<RiotAccount, Long> 
 	@Query("SELECT ra FROM RiotAccount ra WHERE ra.puuid IN :puuids")
 	List<RiotAccount> findByPuuids(@Param("puuids") List<String> puuids);
 
-	Optional<RiotAccount> findByPuuid(String puuid);
-
-	@Query("delete from RiotAccount r where r.member.id = :id")
+	@Query("update RiotAccount r set r.deleted = 1, r.updatedAt = :updatedAt where r.member.id = :id")
 	@Modifying
-	void deleteAllFromMember(@Param("id") Long id);
+	void deleteAllFromMember(@Param("id") Long id, @Param("updatedAt") LocalDateTime updatedAt);
 
 	Optional<RiotAccount> findByMemberIdAndIsMain(Long memberId, Boolean isMain);
 }

--- a/src/main/java/com/gnimty/communityapiserver/domain/schedule/entity/Schedule.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/schedule/entity/Schedule.java
@@ -18,11 +18,13 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Where;
 
 @Entity
 @Table(name = "schedule")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Where(clause = "deleted = 0")
 public class Schedule extends BaseEntity {
 
 	@Id

--- a/src/main/java/com/gnimty/communityapiserver/domain/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/schedule/repository/ScheduleRepository.java
@@ -2,6 +2,7 @@ package com.gnimty.communityapiserver.domain.schedule.repository;
 
 import com.gnimty.communityapiserver.domain.member.entity.Member;
 import com.gnimty.communityapiserver.domain.schedule.entity.Schedule;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -14,7 +15,7 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 
 	void deleteByMember(Member member);
 
-	@Query("delete from Schedule s where s.member.id = :id")
+	@Query("update Schedule s set s.deleted = 1, s.updatedAt = :updatedAt where s.member.id = :id")
 	@Modifying
-	void deleteAllFromMember(@Param("id") Long id);
+	void deleteAllFromMember(@Param("id") Long id, @Param("updatedAt") LocalDateTime updatedAt);
 }


### PR DESCRIPTION
- 회원 탈퇴 시, Member와 연관된 모든 엔티티 deleted = 1 설정
- MemberLike, ChampionComments 같은 경우 Optimistic lock이 적용됐기 때문에, 최대 5번 재시도
- 실제 물리 삭제는 매일 오전 5시에 실행되며, 삭제(deleted=1)됐으며, 날짜 차이가 3일 초과일 경우에 삭제
- 챔피언 운용법의 경우, parent-child 관계 때문에 물리적으로 삭제할 수 없고, "삭제된 댓글입니다." 와 같이 나타내야함