### PR TITLE
Bug/#177 @Version entity, riotaccount.id 수정

### DIFF
--- a/src/main/java/com/gnimty/communityapiserver/domain/championcomments/entity/ChampionComments.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/championcomments/entity/ChampionComments.java
@@ -85,7 +85,6 @@ public class ChampionComments extends BaseEntity {
 	@JoinColumn(name = "parent_champion_comments_id")
 	private ChampionComments parentChampionComments;
 
-	@Column(name = "lock_version")
 	@Version
 	private Long lockVersion;
 

--- a/src/main/java/com/gnimty/communityapiserver/domain/member/entity/Member.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/member/entity/Member.java
@@ -60,7 +60,6 @@ public class Member extends BaseEntity {
 	@NotNull
 	private Long upCount;
 
-	@Column(name = "lock_version")
 	@Version
 	private Long lockVersion;
 

--- a/src/main/java/com/gnimty/communityapiserver/domain/member/service/WithdrawalService.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/member/service/WithdrawalService.java
@@ -47,21 +47,21 @@ public class WithdrawalService {
 	};
 	private static final String UPDATE_MEMBER_SQL = """
 			update member m
-			set m.up_count = m.up_count - 1, m.lock_version = m.lock_version + 1, m.updated_at = ?
+			set m.up_count = m.up_count - 1, m.lockVersion = m.lockVersion + 1, m.updated_at = ?
 			where m.member_id = ?
-			and m.lock_version = ?
+			and m.lockVersion = ?
 		""";
 	private static final String UPDATE_CHAMPION_COMMENTS_LIKE_SQL = """
 			update champion_comments c
-			set c.up_count = c.up_count - 1, c.lock_version = c.lock_version + 1, c.updated_at = ?
+			set c.up_count = c.up_count - 1, c.lockVersion = c.lockVersion + 1, c.updated_at = ?
 			where c.champion_comments_id = ?
-			and c.lock_version = ?
+			and c.lockVersion = ?
 		""";
 	private static final String UPDATE_CHAMPION_COMMENTS_DISLIKE_SQL = """
 			update champion_comments c
-			set c.down_count = c.down_count - 1, c.lock_version = c.lock_version + 1, c.updated_at = ?
+			set c.down_count = c.down_count - 1, c.lockVersion = c.lockVersion + 1, c.updated_at = ?
 			where c.champion_comments_id = ?
-			and c.lock_version = ?
+			and c.lockVersion = ?
 		""";
 
 	private final IntroductionRepository introductionRepository;

--- a/src/main/java/com/gnimty/communityapiserver/domain/riotaccount/repository/RiotAccountQueryRepository.java
+++ b/src/main/java/com/gnimty/communityapiserver/domain/riotaccount/repository/RiotAccountQueryRepository.java
@@ -310,7 +310,7 @@ public class RiotAccountQueryRepository {
 	private BooleanExpression cursorGt(RecommendedSummonersServiceRequest request) {
 		SortBy sortBy = request.getSortBy();
 		if (sortBy == null) {
-			return riotAccount.id.gt(request.getLastSummonerId());
+			return member.id.gt(request.getLastSummonerId());
 		}
 		if (sortBy.equals(SortBy.ATOZ)) {
 			if (request.getLastName() == null || request.getLastSummonerId() == null) {
@@ -318,28 +318,28 @@ public class RiotAccountQueryRepository {
 			}
 			return riotAccount.name.toLowerCase().trim().goe(request.getLastName().toLowerCase().trim())
 				.and(riotAccount.name.toLowerCase().trim().gt(request.getLastName().toLowerCase().trim())
-					.or(riotAccount.id.gt(request.getLastSummonerId())));
+					.or(member.id.gt(request.getLastSummonerId())));
 		} else if (sortBy.equals(SortBy.TIER)) {
 			if (request.getLastSummonerMmr() == null || request.getLastSummonerId() == null) {
 				return null;
 			}
 			return riotAccount.mmr.loe(request.getLastSummonerMmr())
 				.and(riotAccount.mmr.lt(request.getLastSummonerMmr())
-					.or(riotAccount.id.gt(request.getLastSummonerId())));
+					.or(member.id.gt(request.getLastSummonerId())));
 		}
 		if (request.getLastSummonerUpCount() == null || request.getLastSummonerId() == null) {
 			return null;
 		}
 		return member.upCount.loe(request.getLastSummonerUpCount())
 			.and(member.upCount.lt(request.getLastSummonerUpCount())
-				.or(riotAccount.id.gt(request.getLastSummonerId())));
+				.or(member.id.gt(request.getLastSummonerId())));
 	}
 
 	private OrderSpecifier<?>[] createOrderSpecifier(SortBy sortBy) {
 		OrderSpecifier<String> nameAsc = riotAccount.name.toLowerCase().asc();
 		OrderSpecifier<Long> mmrDesc = riotAccount.mmr.desc();
 		OrderSpecifier<Long> upCountDesc = member.upCount.desc();
-		OrderSpecifier<Long> idAsc = riotAccount.id.asc();
+		OrderSpecifier<Long> idAsc = member.id.asc();
 
 		if (sortBy == null) {
 			return new OrderSpecifier[]{idAsc};

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -23,6 +23,8 @@ spring:
       add-mappings: false
   jpa:
     hibernate:
+      naming:
+        physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
       ddl-auto: create-drop
       properties:
         hibernate:


### PR DESCRIPTION
- @Version에 column 제거
- 듀오 찾기 및 소환사 추천에서 RiotAccount의 id 대신 Member의 id로 정렬, 조회